### PR TITLE
Feat: 준비시작 알람 화면 구현

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -9,6 +9,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" /> <!--알림 권한-->
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT"/> <!--풀스크린 인텐트 권한-->
+    <uses-permission android:name="android.permission.TURN_SCREEN_ON"/> <!--화면 띄우기 권한-->
 
     <application
         android:name=".app.OnDotApplication"
@@ -32,7 +35,11 @@
         <activity
             android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
-            android:name=".presentation.MainActivity">
+            android:name=".presentation.MainActivity"
+            android:showWhenLocked="true"
+            android:turnScreenOn="true"
+            android:launchMode="singleTop"
+            tools:targetApi="27">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/app/OnDotApplication.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/app/OnDotApplication.kt
@@ -5,6 +5,7 @@ import com.dh.ondot.BuildConfig
 import com.dh.ondot.core.di.ServiceLocator
 import com.dh.ondot.core.di.provideAlarmScheduler
 import com.dh.ondot.core.di.provideAlarmStorage
+import com.dh.ondot.core.di.provideSoundPlayer
 import com.dh.ondot.core.di.provideTokenProvider
 import com.dh.ondot.core.initKoin
 import com.dh.ondot.util.AppContextHolder
@@ -18,7 +19,8 @@ class OnDotApplication: Application() {
         ServiceLocator.init(
             provideTokenProvider(),
             provideAlarmStorage(),
-            provideAlarmScheduler()
+            provideAlarmScheduler(),
+            provideSoundPlayer()
         )
         initKoin()
     }

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/di/HttpClient.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/di/HttpClient.kt
@@ -8,10 +8,17 @@ import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.logging.SIMPLE
+import io.ktor.client.plugins.observer.ResponseObserver
 import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
+@OptIn(ExperimentalSerializationApi::class)
 actual fun httpClient(): HttpClient = HttpClient(OkHttp) {
     install(ContentNegotiation) {
         json(
@@ -23,11 +30,33 @@ actual fun httpClient(): HttpClient = HttpClient(OkHttp) {
         )
     }
 
+    val prettyJson = Json {
+        prettyPrint        = true
+        prettyPrintIndent  = "  "
+        ignoreUnknownKeys  = true
+        isLenient          = true
+        encodeDefaults     = true
+    }
+
     install(Logging) {
-        logger = object : Logger {
-            override fun log(message: String) = println("Ktor ▶ $message")
+        logger = Logger.SIMPLE
+        level  = if (BuildConfig.DEBUG) LogLevel.HEADERS else LogLevel.NONE
+    }
+
+    install(ResponseObserver) {
+        onResponse { response ->
+            if (response.status.value in 200..299 &&
+                response.headers[HttpHeaders.ContentType]?.startsWith("application/json") == true) {
+                val text = response.bodyAsText()
+
+                try {
+                    val element = prettyJson.parseToJsonElement(text)
+                    println("Ktor ▶\n${prettyJson.encodeToString(element)}")
+                } catch (_: Exception) {
+                    println("Ktor ▶\n$text")
+                }
+            }
         }
-        level = if (BuildConfig.DEBUG) LogLevel.BODY else LogLevel.NONE
     }
 
     defaultRequest { header("Content-Type", "application/json") }

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/util/AlarmService.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/util/AlarmService.kt
@@ -32,7 +32,6 @@ class AlarmService : Service() {
         private const val NOTIFICATION_ID = 1001
     }
 
-
     private val logger = Logger.withTag("AlarmService")
 
     private lateinit var wakeLock: PowerManager.WakeLock
@@ -86,12 +85,12 @@ class AlarmService : Service() {
 
         serviceScope.launch {
             val alarmList = storage.alarmsFlow.first()
-            val alarm = alarmList.firstOrNull { it.alarmId == alarmId }
+            val alarm = alarmList.firstOrNull { it.alarmDetail.alarmId == alarmId }
 
-            logger.d { "Alarm RingTone: ${alarm?.ringTone?.lowercase()}" }
+            logger.d { "Alarm RingTone: ${alarm?.alarmDetail?.ringTone?.lowercase()}" }
 
-            if (alarm != null && alarm.enabled) {
-                soundPlayer.playSound(alarm.ringTone.lowercase()) {
+            if (alarm != null && alarm.alarmDetail.enabled) {
+                soundPlayer.playSound(alarm.alarmDetail.ringTone.lowercase()) {
                     if (wakeLock.isHeld) wakeLock.release()
                     stopForeground(STOP_FOREGROUND_DETACH)
                     stopSelf()
@@ -103,7 +102,7 @@ class AlarmService : Service() {
                     addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
 
                     putExtra("alarmId", alarmId)
-                    putExtra("alarmType", type.name)
+                    putExtra("type", type.name)
                 }
 
                 startActivity(activityIntent)

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/util/AlarmService.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/util/AlarmService.kt
@@ -1,8 +1,10 @@
 package com.dh.ondot.core.util
 
 import android.annotation.SuppressLint
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
@@ -15,7 +17,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import co.touchlab.kermit.Logger
 import com.dh.ondot.R
-import com.dh.ondot.core.di.provideSoundPlayer
+import com.dh.ondot.core.di.ServiceLocator
 import com.dh.ondot.domain.model.enums.AlarmType
 import com.dh.ondot.domain.service.SoundPlayer
 import com.dh.ondot.presentation.MainActivity
@@ -28,7 +30,7 @@ import kotlinx.coroutines.launch
 class AlarmService : Service() {
 
     companion object {
-        private const val CHANNEL_ID = "alarm_channel"
+        private const val CHANNEL_ID = "fucking_alarm_channel"
         private const val NOTIFICATION_ID = 1001
     }
 
@@ -37,7 +39,7 @@ class AlarmService : Service() {
     private lateinit var wakeLock: PowerManager.WakeLock
 
     private val storage by lazy { AndroidAlarmStorage(this) }
-    private val soundPlayer: SoundPlayer by lazy { provideSoundPlayer() }
+    private val soundPlayer: SoundPlayer = ServiceLocator.provideSoundPlayer()
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
@@ -46,26 +48,45 @@ class AlarmService : Service() {
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     @SuppressLint("ForegroundServiceType")
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val alarmId = intent?.getLongExtra("alarmId", -1L) ?: return START_NOT_STICKY
-        val typeName = intent.getStringExtra("type")
+        val alarmId = intent?.getLongExtra("alarmId", -1L) ?: -1L
+        val typeName = intent?.getStringExtra("type")
         val type = typeName?.let { AlarmType.valueOf(it) } ?: AlarmType.Departure
 
+        if (alarmId == -1L && typeName == null) {
+            logger.e { "Invalid extras, stopSelfResult($startId)" }
+            stopSelfResult(startId)
+            return START_NOT_STICKY
+        }
         logger.d { "AlarmService onStartCommand: $alarmId, $type" }
 
-        val chan = NotificationChannel(
-            CHANNEL_ID,
-            "알람 재생 채널",
-            NotificationManager.IMPORTANCE_HIGH
-        ).apply {
-            description = "알람이 울리는 동안 표시되는 채널"
+        val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
+        val isInteractive = pm.isInteractive
+        wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "OnDot:AlarmWakeLock")
+        wakeLock.acquire(2 * 60 * 1000L)
+
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channel = NotificationChannel(CHANNEL_ID, "알람 재생 채널", NotificationManager.IMPORTANCE_HIGH).apply {
+            lockscreenVisibility = Notification.VISIBILITY_PUBLIC
         }
-        (getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
-            .createNotificationChannel(chan)
+        notificationManager.createNotificationChannel(channel)
+
+        val mainIntent = Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            putExtra("alarmId", alarmId)
+            putExtra("type", type.name)
+        }
+        val pendingIntent = PendingIntent.getActivity(this, alarmId.toInt(), mainIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
 
         val notification = NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setContentTitle("알람 재생 중")
             .setContentText("잠시만 기다려주세요")
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_ALARM)
+            .setFullScreenIntent(pendingIntent, true)
+            .setOnlyAlertOnce(true)
             .setOngoing(true)
             .build()
 
@@ -76,12 +97,7 @@ class AlarmService : Service() {
             ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
         )
 
-        val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
-        wakeLock = pm.newWakeLock(
-            PowerManager.PARTIAL_WAKE_LOCK,
-            "OnDot:AlarmWakeLock"
-        )
-        wakeLock.acquire(2 * 60 * 1000L)
+        startActivity(mainIntent)
 
         serviceScope.launch {
             val alarmList = storage.alarmsFlow.first()
@@ -95,17 +111,6 @@ class AlarmService : Service() {
                     stopForeground(STOP_FOREGROUND_DETACH)
                     stopSelf()
                 }
-
-                val activityIntent = Intent(this@AlarmService, MainActivity::class.java).apply {
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                    addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-
-                    putExtra("alarmId", alarmId)
-                    putExtra("type", type.name)
-                }
-
-                startActivity(activityIntent)
             } else {
                 stopSelf()
             }

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/util/AlarmService.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/util/AlarmService.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.launch
 class AlarmService : Service() {
 
     companion object {
-        private const val CHANNEL_ID = "fucking_alarm_channel"
+        private const val CHANNEL_ID = "channel_alarm"
         private const val NOTIFICATION_ID = 1001
     }
 

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/util/AndroidAlarmStorage.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/util/AndroidAlarmStorage.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.dh.ondot.data.dataStore
+import com.dh.ondot.domain.model.ui.AlarmRingInfo
 import com.dh.ondot.domain.service.AlarmStorage
-import com.dh.ondot.domain.model.response.AlarmDetail
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.encodeToString
@@ -19,14 +19,14 @@ class AndroidAlarmStorage(
 
     private val ALARMS_KEY = stringPreferencesKey("alarm_list")
 
-    override val alarmsFlow: Flow<List<AlarmDetail>> = dataStore.data
+    override val alarmsFlow: Flow<List<AlarmRingInfo>> = dataStore.data
         .map { prefs ->
             prefs[ALARMS_KEY]?.let { json ->
-                Json.decodeFromString<List<AlarmDetail>>(json)
+                Json.decodeFromString<List<AlarmRingInfo>>(json)
             } ?: emptyList()
         }
 
-    override suspend fun saveAlarms(alarms: List<AlarmDetail>) {
+    override suspend fun saveAlarms(alarms: List<AlarmRingInfo>) {
         val json = Json.encodeToString(alarms)
         dataStore.edit { prefs ->
             prefs[ALARMS_KEY] = json

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/presentation/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/presentation/MainActivity.kt
@@ -16,15 +16,20 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.core.net.toUri
+import co.touchlab.kermit.Logger
 import com.dh.ondot.App
 import com.dh.ondot.domain.model.enums.AlarmType
 import com.dh.ondot.domain.model.ui.AlarmEvent
 
 class MainActivity : ComponentActivity() {
 
-    private var initialAlarmEvent: AlarmEvent? = null
+    private val logger = Logger.withTag("MainActivity")
+    private var initialAlarmEvent by mutableStateOf<AlarmEvent?>(null)
 
     private val exactAlarmLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -64,6 +69,7 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
 
         parseAlarmEvent(intent)?.let { event ->
+            logger.d { "onNewIntent: $event" }
             initialAlarmEvent = event
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/App.kt
@@ -8,10 +8,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.dh.ondot.core.navigation.NavRoutes
+import com.dh.ondot.core.navigation.alarmNavGraph
 import com.dh.ondot.core.navigation.generalScheduleNavGraph
 import com.dh.ondot.core.navigation.loginNavGraph
 import com.dh.ondot.core.navigation.mainNavGraph
@@ -21,6 +25,7 @@ import com.dh.ondot.core.ui.util.DismissKeyboardOnClick
 import com.dh.ondot.core.ui.util.ToastHost
 import com.dh.ondot.core.util.AlarmNotifier
 import com.dh.ondot.domain.model.ui.AlarmEvent
+import com.dh.ondot.presentation.app.AppViewModel
 import com.dh.ondot.presentation.ui.theme.OnDotTheme
 
 @Composable
@@ -28,11 +33,13 @@ fun App(
     initialAlarm: AlarmEvent? = null
 ) {
     val navController = rememberNavController()
+    val viewModel: AppViewModel = viewModel { AppViewModel() }
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     // android 에서 MainActivity 로부터 전달된 이벤트 처리
     LaunchedEffect(initialAlarm) {
-        initialAlarm?.let { (type, alarmId) ->
-            TODO("네비게이션 로직 구현")
+        initialAlarm?.let { (alarmId, type) ->
+            navController.navigate(NavRoutes.PreparationAlarm.createRoute(alarmId))
         }
     }
 
@@ -77,6 +84,7 @@ fun App(
                     },
                     modifier = Modifier.fillMaxSize()
                 ) {
+                    alarmNavGraph(navController)
                     splashNavGraph(navController = navController)
                     loginNavGraph(navController = navController)
                     onboardingNavGraph(navController = navController)

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/SharedInit.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/SharedInit.kt
@@ -4,6 +4,7 @@ import com.dh.ondot.core.di.ServiceLocator
 import com.dh.ondot.core.di.appModule
 import com.dh.ondot.core.di.provideAlarmScheduler
 import com.dh.ondot.core.di.provideAlarmStorage
+import com.dh.ondot.core.di.provideSoundPlayer
 import com.dh.ondot.core.di.provideTokenProvider
 import org.koin.core.context.startKoin
 
@@ -11,7 +12,8 @@ fun initShared() {
     ServiceLocator.init(
         provideTokenProvider(),
         provideAlarmStorage(),
-        provideAlarmScheduler()
+        provideAlarmScheduler(),
+        provideSoundPlayer()
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/di/ServiceLocator.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/di/ServiceLocator.kt
@@ -4,12 +4,13 @@ import com.dh.ondot.data.repository.AuthRepositoryImpl
 import com.dh.ondot.data.repository.MemberRepositoryImpl
 import com.dh.ondot.data.repository.PlaceRepositoryImpl
 import com.dh.ondot.data.repository.ScheduleRepositoryImpl
-import com.dh.ondot.domain.service.AlarmScheduler
-import com.dh.ondot.domain.service.AlarmStorage
 import com.dh.ondot.domain.repository.AuthRepository
 import com.dh.ondot.domain.repository.MemberRepository
 import com.dh.ondot.domain.repository.PlaceRepository
 import com.dh.ondot.domain.repository.ScheduleRepository
+import com.dh.ondot.domain.service.AlarmScheduler
+import com.dh.ondot.domain.service.AlarmStorage
+import com.dh.ondot.domain.service.SoundPlayer
 import com.dh.ondot.network.NetworkClient
 import com.dh.ondot.network.TokenProvider
 
@@ -18,6 +19,7 @@ object ServiceLocator {
     private lateinit var networkClient: NetworkClient
     private lateinit var alarmStorage: AlarmStorage
     private lateinit var alarmScheduler: AlarmScheduler
+    private lateinit var soundPlayer: SoundPlayer
 
     val authRepository: AuthRepository by lazy {
         AuthRepositoryImpl(networkClient, tokenProvider)
@@ -38,16 +40,19 @@ object ServiceLocator {
     fun init(
         tokenProvider: TokenProvider,
         alarmStorage: AlarmStorage,
-        alarmScheduler: AlarmScheduler
+        alarmScheduler: AlarmScheduler,
+        soundPlayer: SoundPlayer
     ) {
         this.tokenProvider = tokenProvider
         this.networkClient = NetworkClient(tokenProvider)
         this.alarmStorage = alarmStorage
         this.alarmScheduler = alarmScheduler
+        this.soundPlayer = soundPlayer
     }
 
     fun provideNetworkClient(): NetworkClient = networkClient
     fun provideTokenProvider(): TokenProvider = tokenProvider
     fun provideAlarmStorage(): AlarmStorage = alarmStorage
     fun provideAlarmScheduler(): AlarmScheduler = alarmScheduler
+    fun provideSoundPlayer(): SoundPlayer = soundPlayer
 }

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/navigation/NavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/navigation/NavGraph.kt
@@ -4,9 +4,13 @@ import androidx.compose.runtime.remember
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import androidx.navigation.navigation
+import androidx.navigation.toRoute
 import com.dh.ondot.core.di.GeneralScheduleViewModelFactory
+import com.dh.ondot.presentation.alarm.preparation.PreparationAlarmRingScreen
 import com.dh.ondot.presentation.general.GeneralScheduleViewModel
 import com.dh.ondot.presentation.general.check.CheckScheduleScreen
 import com.dh.ondot.presentation.general.loading.RouteLoadingScreen
@@ -16,6 +20,33 @@ import com.dh.ondot.presentation.login.LoginScreen
 import com.dh.ondot.presentation.main.MainScreen
 import com.dh.ondot.presentation.onboarding.OnboardingScreen
 import com.dh.ondot.presentation.splash.SplashScreen
+
+fun NavGraphBuilder.alarmNavGraph(
+    navController: NavHostController
+) {
+    navigation(
+        startDestination = NavRoutes.PreparationAlarm.ROUTE,
+        route = NavRoutes.AlarmGraph.route
+    ) {
+        composable(
+            NavRoutes.PreparationAlarm.ROUTE,
+            arguments = listOf(navArgument("alarmId") { type = NavType.LongType })
+        ) { backStackEntry ->
+            val args = backStackEntry.toRoute<NavRoutes.PreparationAlarm>()
+            val alarmId = args.alarmId
+
+            PreparationAlarmRingScreen(
+                alarmId = alarmId,
+                navigateToSplash = {
+                    navController.navigate(NavRoutes.Splash.route) {
+                        popUpTo(NavRoutes.AlarmGraph.route) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                }
+            )
+        }
+    }
+}
 
 fun NavGraphBuilder.splashNavGraph(navController: NavHostController) {
     navigation(

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/navigation/NavRoutes.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/navigation/NavRoutes.kt
@@ -1,6 +1,22 @@
 package com.dh.ondot.core.navigation
 
-sealed class NavRoutes(val route: String) {
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+@Serializable
+sealed class NavRoutes(@Transient val route: String = "") {
+    // Alarm
+    @Serializable
+    data object AlarmGraph: NavRoutes("alarmGraph")
+    @Serializable
+    data class PreparationAlarm(val alarmId: Long) : NavRoutes("preparationAlarm/{alarmId}") {
+        companion object {
+            const val ROUTE: String = "preparationAlarm/{alarmId}"
+            fun createRoute(id: Long) = "preparationAlarm/$id"
+        }
+    }
+
+
     // Splash
     data object SplashGraph: NavRoutes("splashGraph")
     data object Splash: NavRoutes("splash")

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/util/DateTimeFormatter.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/util/DateTimeFormatter.kt
@@ -4,6 +4,7 @@ import com.dh.ondot.presentation.ui.theme.WORD_AM
 import com.dh.ondot.presentation.ui.theme.WORD_PM
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
@@ -26,6 +27,23 @@ object DateTimeFormatter {
         /** 원하는 구분자(delim)로 "yyyy{delim}MM{delim}DD" 포맷 */
         fun format(delim: String = "."): String =
             listOf(year, month.to2(), day.to2()).joinToString(delim)
+
+        /** 06월 13일 화요일 형태로 포맷 */
+        fun formatKoreanDate(): String {
+            val date = LocalDate(year, month, day)
+            val dayOfWeekKorean = when (date.dayOfWeek) {
+                DayOfWeek.MONDAY    -> "월요일"
+                DayOfWeek.TUESDAY   -> "화요일"
+                DayOfWeek.WEDNESDAY -> "수요일"
+                DayOfWeek.THURSDAY  -> "목요일"
+                DayOfWeek.FRIDAY    -> "금요일"
+                DayOfWeek.SATURDAY  -> "토요일"
+                DayOfWeek.SUNDAY    -> "일요일"
+                else -> ""
+            }
+
+            return "${month.pad2()}월 ${day.pad2()}일 $dayOfWeekKorean"
+        }
     }
 
     private fun parseYMD(iso: String): YMD {
@@ -46,6 +64,9 @@ object DateTimeFormatter {
     }
 
     fun formatDate(iso: String, delimiter: String = "."): String = parseYMD(iso).format(delimiter)
+
+    /** 06월 13일 화요일 형태로 포맷 */
+    fun formatKoreanDate(iso: String): String = parseYMD(iso).formatKoreanDate()
 
     /** 주어진 연,월의 1일부터 마지막 일까지 리스트로 생성 */
     fun monthDays(year: Int, month: Int): List<LocalDate> {
@@ -70,6 +91,19 @@ object DateTimeFormatter {
         private fun Int.pad2() = this.toString().padStart(2, '0')
         /** "오전 1:05" 같은 형태로 포맷 */
         fun format(): String = "$period $hour12:${minute.pad2()}"
+
+        /** 23:05 같은 형태로 포맷 */
+        fun formatHourMinute(): String = "${hour12.pad2()}:${minute.pad2()}"
+    }
+
+    data class HourMinuteSecond(
+        val hour: Int,
+        val minute: Int,
+        val second: Int
+    ) {
+        private fun Int.pad2() = this.toString().padStart(2, '0')
+        /** "01:00:00" 형태로 포맷 */
+        fun format(): String = "${hour.pad2()}:${minute.pad2()}:${second.pad2()}"
     }
 
     private fun parseAmPmTime(iso: String): AmPmTime {
@@ -88,6 +122,21 @@ object DateTimeFormatter {
 
     /** "오전 01:05" 같은 형태로 포맷 */
     fun formatAmPmTime(iso: String): String = parseAmPmTime(iso).format()
+
+    /** "23:05" 같은 형태로 포맷 */
+    fun formatHourMinute(iso: String): String = parseAmPmTime(iso).formatHourMinute()
+
+    private fun parseHourMinuteSecond(iso: String): HourMinuteSecond {
+        val localDt = LocalDateTime.parse(iso)
+        val h24    = localDt.hour
+        val minute = localDt.minute
+        val second = localDt.second
+
+        return HourMinuteSecond(h24, minute, second)
+    }
+
+    /** "01:00:00" 같은 형태로 포맷 */
+    fun formatHourMinuteSecond(iso: String): String = parseHourMinuteSecond(iso).format()
 
     /** Pair("오전", "01:05") 같은 형태로 포맷 */
     fun formatAmPmTimePair(iso: String): Pair<String, String> {

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/util/DateTimeFormatter.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/util/DateTimeFormatter.kt
@@ -93,7 +93,15 @@ object DateTimeFormatter {
         fun format(): String = "$period $hour12:${minute.pad2()}"
 
         /** 23:05 같은 형태로 포맷 */
-        fun formatHourMinute(): String = "${hour12.pad2()}:${minute.pad2()}"
+        fun formatHourMinute(): String {
+            val hour24 = when {
+                period == WORD_AM && hour12 == 12 -> 0
+                period == WORD_AM -> hour12
+                period == WORD_PM && hour12 == 12 -> 12
+                else -> hour12
+            }
+            return "${hour24.pad2()}:${minute.pad2()}"
+        }
     }
 
     data class HourMinuteSecond(

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/domain/model/request/CreateScheduleRequest.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/domain/model/request/CreateScheduleRequest.kt
@@ -10,6 +10,8 @@ data class CreateScheduleRequest(
     val isRepeat: Boolean,
     val repeatDays: List<Int>,
     val appointmentAt: String,
+    val isMedicationRequired: Boolean,
+    val preparationNote: String,
     val departurePlace: AddressInfo,
     val arrivalPlace: AddressInfo,
     val preparationAlarm: AlarmDetail,

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/domain/model/ui/AlarmRingInfo.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/domain/model/ui/AlarmRingInfo.kt
@@ -1,0 +1,14 @@
+package com.dh.ondot.domain.model.ui
+
+import com.dh.ondot.domain.model.enums.AlarmType
+import com.dh.ondot.domain.model.response.AlarmDetail
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AlarmRingInfo(
+    val alarmDetail: AlarmDetail = AlarmDetail(),
+    val alarmType: AlarmType = AlarmType.Departure,
+    val appointmentAt: String = "",
+    val scheduleTitle: String = "",
+    val scheduleId: Long = -1L
+)

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/domain/service/AlarmStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/domain/service/AlarmStorage.kt
@@ -1,9 +1,9 @@
 package com.dh.ondot.domain.service
 
-import com.dh.ondot.domain.model.response.AlarmDetail
+import com.dh.ondot.domain.model.ui.AlarmRingInfo
 import kotlinx.coroutines.flow.Flow
 
 interface AlarmStorage {
-    suspend fun saveAlarms(alarms: List<AlarmDetail>)
-    val alarmsFlow: Flow<List<AlarmDetail>>
+    suspend fun saveAlarms(alarms: List<AlarmRingInfo>)
+    val alarmsFlow: Flow<List<AlarmRingInfo>>
 }

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/alarm/preparation/PraparationAlarmRingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/alarm/preparation/PraparationAlarmRingScreen.kt
@@ -185,8 +185,8 @@ private fun SnoozeButton(
 ) {
     Box(
         modifier = Modifier
-            .padding(vertical = 18.dp, horizontal = 28.dp)
             .background(Gray700, RoundedCornerShape(12.dp))
+            .padding(vertical = 18.dp, horizontal = 28.dp)
             .clip(RoundedCornerShape(12.dp))
             .clickable { onClick() },
         contentAlignment = Alignment.Center

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/alarm/preparation/PraparationAlarmRingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/alarm/preparation/PraparationAlarmRingScreen.kt
@@ -1,0 +1,287 @@
+package com.dh.ondot.presentation.alarm.preparation
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.dh.ondot.core.util.DateTimeFormatter
+import com.dh.ondot.domain.model.enums.ButtonType
+import com.dh.ondot.domain.model.enums.OnDotTextStyle
+import com.dh.ondot.domain.model.response.AlarmDetail
+import com.dh.ondot.getPlatform
+import com.dh.ondot.presentation.app.AppViewModel
+import com.dh.ondot.presentation.ui.components.OnDotButton
+import com.dh.ondot.presentation.ui.components.OnDotHighlightText
+import com.dh.ondot.presentation.ui.components.OnDotText
+import com.dh.ondot.presentation.ui.theme.ANDROID
+import com.dh.ondot.presentation.ui.theme.OnDotColor.Gray0
+import com.dh.ondot.presentation.ui.theme.OnDotColor.Gray200
+import com.dh.ondot.presentation.ui.theme.OnDotColor.Gray700
+import com.dh.ondot.presentation.ui.theme.OnDotColor.Gray900
+import com.dh.ondot.presentation.ui.theme.OnDotColor.Green500
+import com.dh.ondot.presentation.ui.theme.OnDotColor.Red
+import com.dh.ondot.presentation.ui.theme.PREPARATION_START_BUTTON_TEXT
+import com.dh.ondot.presentation.ui.theme.alarmRingTitle
+import com.dh.ondot.presentation.ui.theme.formatRemainingSnoozeTime
+import com.dh.ondot.presentation.ui.theme.snoozeIntervalLabel
+import io.github.alexzhirkevich.compottie.Compottie
+import io.github.alexzhirkevich.compottie.LottieCompositionSpec
+import io.github.alexzhirkevich.compottie.animateLottieCompositionAsState
+import io.github.alexzhirkevich.compottie.rememberLottieComposition
+import io.github.alexzhirkevich.compottie.rememberLottiePainter
+import kotlinx.coroutines.delay
+import ondot.composeapp.generated.resources.Res
+
+@Composable
+fun PreparationAlarmRingScreen(
+    alarmId: Long,
+    navigateToSplash: () -> Unit
+) {
+    val viewModel: AppViewModel = viewModel { AppViewModel() }
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(alarmId) {
+        if (alarmId != -1L) {
+            viewModel.getAlarmInfo(alarmId)
+        }
+    }
+
+    LaunchedEffect(uiState.showPreparationStartAnimation) {
+        if (uiState.showPreparationStartAnimation) {
+            delay(2000L)
+            navigateToSplash()
+        }
+    }
+
+    if (uiState.alarmRingInfo.appointmentAt.isNotBlank()) {
+        PreparationAlarmRingContent(
+            alarmDetail = uiState.alarmRingInfo.alarmDetail,
+            appointmentAt = uiState.alarmRingInfo.appointmentAt,
+            scheduleTitle = uiState.alarmRingInfo.scheduleTitle,
+            showPreparationStartAnimation = uiState.showPreparationStartAnimation,
+            onClickPreparationStartButton = { viewModel.onPreparationStart() }
+        )
+    } else {
+        Box(modifier = Modifier.fillMaxSize().background(Gray900))
+    }
+}
+
+@Composable
+fun PreparationAlarmRingContent(
+    alarmDetail: AlarmDetail,
+    appointmentAt: String,
+    scheduleTitle: String,
+    showPreparationStartAnimation: Boolean,
+    onClickPreparationStartButton: () -> Unit
+) {
+    val formattedTime = DateTimeFormatter.formatHourMinuteSecond(alarmDetail.triggeredAt)
+    val alarmRingTitle = alarmRingTitle(formattedTime)
+    val appointmentDate = DateTimeFormatter.formatKoreanDate(appointmentAt)
+    val appointmentTime = DateTimeFormatter.formatHourMinute(appointmentAt)
+    var isSnoozed by remember { mutableStateOf(false) }
+    val composition by rememberLottieComposition {
+        LottieCompositionSpec.JsonString(Res.readBytes("files/lotties/preparation_start.json").decodeToString())
+    }
+    val progress by animateLottieCompositionAsState(
+        composition,
+        iterations = Compottie.IterateForever
+    )
+
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Gray900)
+                .padding(horizontal = 22.dp)
+                .padding(bottom = if (getPlatform().name == ANDROID) 16.dp else 37.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(69.dp))
+
+            AlarmRingTitle(alarmRingTitle, formattedTime)
+
+            if (isSnoozed) {
+                AlarmSnoozedSection(alarmDetail.snoozeInterval)
+            } else {
+                ScheduleInfoSection(
+                    snoozeInterval = alarmDetail.snoozeInterval,
+                    appointmentDate = appointmentDate,
+                    appointmentTime = appointmentTime,
+                    scheduleTitle = scheduleTitle,
+                    onClickSnooze = { isSnoozed = true }
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            OnDotButton(
+                buttonText = PREPARATION_START_BUTTON_TEXT,
+                buttonType = ButtonType.Green500,
+                onClick = onClickPreparationStartButton
+            )
+        }
+
+        if (showPreparationStartAnimation) {
+            Box(
+                modifier = Modifier.fillMaxSize().background(Gray900)
+            ) {
+                Image(
+                    painter = rememberLottiePainter(
+                        composition = composition,
+                        progress = { progress }
+                    ),
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Fit
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlarmRingTitle(
+    title: String,
+    highlight: String,
+) {
+    OnDotHighlightText(
+        text = title,
+        textColor = Gray0,
+        highlight = highlight,
+        highlightColor = Green500,
+        style = OnDotTextStyle.TitleMediumSB,
+        textAlign = TextAlign.Center
+    )
+}
+
+@Composable
+private fun SnoozeButton(
+    snoozeInterval: Int,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .padding(vertical = 18.dp, horizontal = 28.dp)
+            .background(Gray700, RoundedCornerShape(12.dp))
+            .clip(RoundedCornerShape(12.dp))
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        OnDotText(text = snoozeIntervalLabel(snoozeInterval), style = OnDotTextStyle.TitleSmallSB, color = Gray200)
+    }
+}
+
+@Composable
+private fun ScheduleInfoSection(
+    snoozeInterval: Int,
+    appointmentDate: String,
+    appointmentTime: String,
+    scheduleTitle: String,
+    onClickSnooze: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(54.dp))
+
+        OnDotText(
+            text = appointmentDate,
+            style = OnDotTextStyle.TitleSmallM,
+            color = Gray0
+        )
+
+        OnDotText(
+            text = appointmentTime,
+            style = OnDotTextStyle.TitleLargeM,
+            color = Gray0
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OnDotText(
+            text = scheduleTitle,
+            style = OnDotTextStyle.BodyLargeR1,
+            color = Gray0
+        )
+
+        Spacer(modifier = Modifier.height(213.dp))
+
+        SnoozeButton(
+            snoozeInterval = snoozeInterval,
+            onClick = onClickSnooze
+        )
+    }
+}
+
+@Composable
+private fun AlarmSnoozedSection(
+    snoozeInterval: Int
+) {
+    val composition by rememberLottieComposition {
+        LottieCompositionSpec.JsonString(Res.readBytes("files/lotties/preparation_alarm_snoozed.json").decodeToString())
+    }
+    val progress by animateLottieCompositionAsState(
+        composition,
+        iterations = Compottie.IterateForever
+    )
+    val totalSeconds = snoozeInterval * 60
+    val timeLeftSecond by produceState(initialValue = totalSeconds) {
+        var current = totalSeconds
+
+        while (current >= 0) {
+            delay(1000)
+            current--
+            value = current
+        }
+    }
+    val minutes = timeLeftSecond / 60
+    val seconds = timeLeftSecond % 60
+    val timeText = formatRemainingSnoozeTime(minutes, seconds)
+
+    Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.TopCenter
+    ) {
+        Image(
+            painter = rememberLottiePainter(
+                composition = composition,
+                progress = { progress }
+            ),
+            contentDescription = null,
+            modifier = Modifier.fillMaxWidth(),
+            contentScale = ContentScale.Fit
+        )
+
+        OnDotText(
+            text = timeText,
+            style = OnDotTextStyle.TitleLargeM,
+            color = Red
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/alarm/preparation/PraparationAlarmRingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/alarm/preparation/PraparationAlarmRingScreen.kt
@@ -254,7 +254,7 @@ private fun AlarmSnoozedSection(
     val timeLeftSecond by produceState(initialValue = totalSeconds) {
         var current = totalSeconds
 
-        while (current >= 0) {
+        while (current > 0) {
             delay(1000)
             current--
             value = current

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/alarm/preparation/PreparationAlarmRingEvent.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/alarm/preparation/PreparationAlarmRingEvent.kt
@@ -1,0 +1,7 @@
+package com.dh.ondot.presentation.alarm.preparation
+
+import com.dh.ondot.core.ui.base.Event
+
+sealed class PreparationAlarmRingEvent: Event {
+    data object NavigateToSplash: PreparationAlarmRingEvent()
+}

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/app/AppEvent.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/app/AppEvent.kt
@@ -1,0 +1,7 @@
+package com.dh.ondot.presentation.app
+
+import com.dh.ondot.core.ui.base.Event
+
+sealed class AppEvent: Event {
+    data object NavigateToPreparationAlarmRing: AppEvent()
+}

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/app/AppUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/app/AppUiState.kt
@@ -1,0 +1,9 @@
+package com.dh.ondot.presentation.app
+
+import com.dh.ondot.core.ui.base.UiState
+import com.dh.ondot.domain.model.ui.AlarmRingInfo
+
+data class AppUiState(
+    val alarmRingInfo: AlarmRingInfo = AlarmRingInfo(),
+    val showPreparationStartAnimation: Boolean = false,
+): UiState

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/app/AppViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/app/AppViewModel.kt
@@ -1,0 +1,38 @@
+package com.dh.ondot.presentation.app
+
+import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
+import com.dh.ondot.core.di.ServiceLocator
+import com.dh.ondot.core.ui.base.BaseViewModel
+import com.dh.ondot.domain.service.AlarmScheduler
+import com.dh.ondot.domain.service.AlarmStorage
+import com.dh.ondot.domain.service.SoundPlayer
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+class AppViewModel(
+    private val alarmScheduler: AlarmScheduler = ServiceLocator.provideAlarmScheduler(),
+    private val alarmStorage: AlarmStorage = ServiceLocator.provideAlarmStorage(),
+    private val soundPlayer: SoundPlayer = ServiceLocator.provideSoundPlayer()
+): BaseViewModel<AppUiState>(AppUiState()) {
+    private val logger = Logger.withTag("AppViewModel")
+
+    fun getAlarmInfo(alarmId: Long) {
+        viewModelScope.launch {
+            val allAlarms = alarmStorage.alarmsFlow.first()
+
+            logger.d { "allAlarms: $allAlarms" }
+
+            val alarm = allAlarms.firstOrNull { it.alarmDetail.alarmId == alarmId } ?: return@launch
+
+            logger.d { "alarm: $alarm" }
+
+            updateStateSync(uiState.value.copy(alarmRingInfo = alarm))
+        }
+    }
+
+    fun onPreparationStart() {
+        soundPlayer.stopSound()
+        updateState(uiState.value.copy(showPreparationStartAnimation = true))
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/general/GeneralScheduleViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/general/GeneralScheduleViewModel.kt
@@ -283,6 +283,8 @@ class GeneralScheduleViewModel(
             title = uiState.value.scheduleTitle,
             isRepeat = uiState.value.isRepeat,
             repeatDays = uiState.value.activeWeekDays.map { it + 1 }.toList(),
+            isMedicationRequired = false,
+            preparationNote = "",
             departurePlace = departurePlace,
             arrivalPlace = arrivalPlace,
             appointmentAt = appointmentAt,

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/ui/theme/String.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/ui/theme/String.kt
@@ -32,6 +32,7 @@ const val CATEGORY_FAST_INTENSE = "빠르고 강렬한"
 // 버튼 텍스트
 const val KAKAO_LOGIN_BUTTON_TEXT = "카카오로 계속하기"
 const val CREATE_SCHEDULE = "일정 생성"
+const val PREPARATION_START_BUTTON_TEXT = "준비 시작하기"
 
 // ERROR
 const val ERROR_GET_SCHEDULE_LIST = "일정 조회에 실패했습니다."
@@ -96,3 +97,8 @@ const val SETTING_ALARM_DEFAULT = "알람 초기값 설정"
 const val SETTING_PREPARE_TIME = "준비 시간 설정"
 const val SETTING_CUSTOMER_SERVICE = "고객센터"
 const val SETTING_SERVICE_POLICY = "서비스 정책"
+
+// Alarm
+fun alarmRingTitle(time: String) = "출발하기까지 $time\n어서 준비를 시작하세요!"
+fun snoozeIntervalLabel(snoozeInterval: Int) = "${snoozeInterval}분 알람 미루기"
+fun formatRemainingSnoozeTime(minute: Int, second: Int) = "${minute}:${second}"

--- a/composeApp/src/iosMain/kotlin/com/dh/ondot/core/util/IosAlarmStorage.kt
+++ b/composeApp/src/iosMain/kotlin/com/dh/ondot/core/util/IosAlarmStorage.kt
@@ -1,7 +1,7 @@
 package com.dh.ondot.core.util
 
+import com.dh.ondot.domain.model.ui.AlarmRingInfo
 import com.dh.ondot.domain.service.AlarmStorage
-import com.dh.ondot.domain.model.response.AlarmDetail
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -15,19 +15,19 @@ class IosAlarmStorage: AlarmStorage {
 
     private val defaults: NSUserDefaults = NSUserDefaults.standardUserDefaults()
     private val _alarmsFlow = MutableStateFlow(getAlarms())
-    override val alarmsFlow: Flow<List<AlarmDetail>> = _alarmsFlow.asStateFlow()
+    override val alarmsFlow: Flow<List<AlarmRingInfo>> = _alarmsFlow.asStateFlow()
 
-    override suspend fun saveAlarms(alarms: List<AlarmDetail>) {
+    override suspend fun saveAlarms(alarms: List<AlarmRingInfo>) {
         // JSON 으로 직렬화하여 UserDefaults 에 저장
         val json = Json.encodeToString(alarms)
         defaults.setObject(json, ALARMS_KEY)
         defaults.synchronize()
 
-        // 2) Flow 에 새 값 방출
+        // Flow 에 새 값 방출
         _alarmsFlow.value = alarms
     }
 
-    private fun getAlarms(): List<AlarmDetail> {
+    private fun getAlarms(): List<AlarmRingInfo> {
         // UserDefaults 에서 꺼낸 문자열이 없으면 빈 리스트
         val json = defaults.stringForKey(ALARMS_KEY) ?: return emptyList()
         return try {

--- a/iosApp/iosApp/AppDelegate.swift
+++ b/iosApp/iosApp/AppDelegate.swift
@@ -29,7 +29,9 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                 // 원격(푸시) 알림 수신을 위해 APNs 서버에 디바이스 토큰 등록
                 // APNs(Apple Push Notification service) 서버로 디바이스 토큰을 요청
                 // application(_:didRegisterForRemoteNotificationsWithDeviceToken:) 콜백에서 토큰을 받아와 서버와 연동할 수 있음
-                application.registerForRemoteNotifications()
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
             } else {
                 // 권한이 거부되었을 때 처리
                 self.handleNotificationPermissionDenied()


### PR DESCRIPTION
## 이슈 번호
- close #31 

## 작업내용
### commonMain
- [x] PreparationAlarmRingScreen Composable 구현
- [x] App Composable에서 AlarmEvent 수신 후, 알람 정보 조회 및 PreparationAlarmScreen에 전달
- [x] 알람 미루기 실행 시 화면 전환


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 알람 준비 화면 및 알림 준비 애니메이션, 스누즈 타이머, 알람 정보 표시 등 알람 준비 관련 UI가 추가되었습니다.
  * 알람 관련 상세 정보(시간, 제목 등)를 담는 새로운 데이터 구조가 도입되었습니다.
  * 일정 생성 시 복약 필요 여부와 준비 메모 입력 기능이 추가되었습니다.
  * 알람 준비 관련 내비게이션 경로 및 화면 이동이 지원됩니다.

* **개선 및 변경**
  * 알람 저장/조회 방식이 개선되어 더 많은 정보를 포함합니다.
  * 알람 울림 시 알림, 화면 깨우기, 잠금화면 표시 등 Android 권한 및 동작이 강화되었습니다.
  * 알림 권한 요청 및 거부 시 설정 화면 이동 등 사용자 경험이 향상되었습니다.
  * 알람 및 일정 관련 날짜·시간 포맷 기능이 확장되었습니다.
  * 알람 준비 버튼, 스누즈 등 UI 텍스트 및 포맷 함수가 추가되었습니다.
  * 네트워크 요청 로깅 및 응답 처리 방식이 개선되었습니다.

* **버그 수정**
  * Android 및 iOS에서 알람 저장 방식이 일관되게 동작하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->