### PR TITLE
Feat: 일정 생성 준비물, 약 바텀시트 구현

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/ui/extensions/ButtonStyles.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/ui/extensions/ButtonStyles.kt
@@ -14,6 +14,7 @@ fun ButtonType.styles(): ButtonStyle {
         ButtonType.Green500 -> ButtonStyle(backgroundColor = OnDotColor.Green500, fontColor = OnDotColor.Gray900)
         ButtonType.Green600 -> ButtonStyle(backgroundColor = OnDotColor.Green600, fontColor = OnDotColor.Gray900)
         ButtonType.Gray300 -> ButtonStyle(backgroundColor = OnDotColor.Gray300, fontColor = OnDotColor.Gray900)
+        ButtonType.Gray400 -> ButtonStyle(backgroundColor = OnDotColor.Gray400, fontColor = OnDotColor.Gray0)
         ButtonType.Gradient -> ButtonStyle(backgroundColor = OnDotColor.Gray700, fontColor = OnDotColor.Gray0)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/domain/model/enums/ButtonType.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/domain/model/enums/ButtonType.kt
@@ -5,5 +5,6 @@ enum class ButtonType {
     Green500,
     Green600,
     Gray300,
+    Gray400,
     Gradient
 }

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/general/GeneralScheduleUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/general/GeneralScheduleUiState.kt
@@ -50,5 +50,6 @@ data class GeneralScheduleUiState(
 
     // CheckSchedule
     val scheduleTitle: String = NEW_SCHEDULE_LABEL,
+    val showBottomSheet: Boolean = false,
 
 ): UiState

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/general/GeneralScheduleViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/general/GeneralScheduleViewModel.kt
@@ -274,7 +274,7 @@ class GeneralScheduleViewModel(
 
     /**--------------------------------------------CheckSchedule-----------------------------------------------*/
 
-    fun createSchedule() {
+    fun createSchedule(isChecked: Boolean, input: String) {
         val (date, time, places) = validateScheduleInputs()
         val (departurePlace, arrivalPlace) = places
         val appointmentAt = DateTimeFormatter.formatIsoDateTime(date, time)
@@ -283,8 +283,8 @@ class GeneralScheduleViewModel(
             title = uiState.value.scheduleTitle,
             isRepeat = uiState.value.isRepeat,
             repeatDays = uiState.value.activeWeekDays.map { it + 1 }.toList(),
-            isMedicationRequired = false,
-            preparationNote = "",
+            isMedicationRequired = isChecked,
+            preparationNote = input,
             departurePlace = departurePlace,
             arrivalPlace = arrivalPlace,
             appointmentAt = appointmentAt,
@@ -314,6 +314,10 @@ class GeneralScheduleViewModel(
 
     fun updatePreparationAlarmEnabled() {
         updateState(uiState.value.copy(preparationAlarm = uiState.value.preparationAlarm.copy(enabled = !uiState.value.preparationAlarm.enabled)))
+    }
+
+    fun updateBottomSheetVisible(visible: Boolean) {
+        updateState(uiState.value.copy(showBottomSheet = visible))
     }
 
     /**--------------------------------------------ETC-----------------------------------------------*/

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/general/repeat/ScheduleRepeatSettingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/general/repeat/ScheduleRepeatSettingScreen.kt
@@ -158,7 +158,7 @@ fun ScheduleRepeatSettingContent(
         OnDotButton(
             buttonText = WORD_NEXT,
             buttonType = if (isButtonEnabled) ButtonType.Green500 else ButtonType.Gray300,
-            onClick = onClickButton
+            onClick = { if (isButtonEnabled) onClickButton() }
         )
 
         Spacer(modifier = Modifier.height(if (getPlatform().name == ANDROID) 16.dp else 37.dp))

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/ui/components/OnDotBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/ui/components/OnDotBottomSheet.kt
@@ -5,13 +5,19 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.dh.ondot.presentation.ui.theme.OnDotColor.Gray700
@@ -23,6 +29,7 @@ fun OnDotBottomSheet(
     onDismiss: () -> Unit
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+    val scrollState = rememberScrollState()
 
     Box(
         modifier = Modifier
@@ -32,17 +39,33 @@ fun OnDotBottomSheet(
                 indication = null,
                 interactionSource = interactionSource,
                 onClick = onDismiss
-            )
+            ),
+        contentAlignment = Alignment.BottomCenter
     ) {
-        Column(
+        BoxWithConstraints(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(Gray700, RoundedCornerShape(topEnd = 20.dp, topStart = 20.dp))
-                .padding(horizontal = 22.dp)
-                .padding(top = 32.dp, bottom = 50.dp),
-            verticalArrangement = Arrangement.Bottom
+                .clickable(
+                    indication = null,
+                    interactionSource = interactionSource,
+                    onClick = {} // 내부 클릭 이벤트 소비
+                )
         ) {
-            content()
+            val maxSheetHeight = maxHeight * 0.6f
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = maxSheetHeight)
+                    .verticalScroll(scrollState)
+                    .background(Gray700, RoundedCornerShape(topEnd = 20.dp, topStart = 20.dp))
+                    .imePadding()
+                    .padding(horizontal = 22.dp)
+                    .padding(top = 32.dp, bottom = 50.dp),
+                verticalArrangement = Arrangement.Bottom
+            ) {
+                content()
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/ui/components/OnDotBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/ui/components/OnDotBottomSheet.kt
@@ -1,0 +1,48 @@
+package com.dh.ondot.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.dh.ondot.presentation.ui.theme.OnDotColor.Gray700
+import com.dh.ondot.presentation.ui.theme.OnDotColor.Gray900
+
+@Composable
+fun OnDotBottomSheet(
+    content: @Composable () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Gray900.copy(alpha = 0.8f))
+            .clickable(
+                indication = null,
+                interactionSource = interactionSource,
+                onClick = onDismiss
+            )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Gray700, RoundedCornerShape(topEnd = 20.dp, topStart = 20.dp))
+                .padding(horizontal = 22.dp)
+                .padding(top = 32.dp, bottom = 50.dp),
+            verticalArrangement = Arrangement.Bottom
+        ) {
+            content()
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/ui/components/RoundedTextField.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/ui/components/RoundedTextField.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -31,10 +32,12 @@ fun RoundedTextField(
     value: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
+    backgroundColor: Color = OnDotColor.Gray700,
     placeholder: String = "",
     enabled: Boolean = true,
     maxLength: Int = 5,
     maxLines: Int = 1,
+    singleLine: Boolean = true,
     icon: @Composable (() -> Unit)? = null,
     readOnly: Boolean = false,
     onClickWhenReadOnly: () -> Unit = {},
@@ -47,7 +50,7 @@ fun RoundedTextField(
 
     Box(
         modifier = modifier
-            .background(color = OnDotColor.Gray700, shape = RoundedCornerShape(12.dp))
+            .background(color = backgroundColor, shape = RoundedCornerShape(12.dp))
             .border(
                 width = 1.dp,
                 color = OnDotColor.Gray600,
@@ -93,7 +96,7 @@ fun RoundedTextField(
                         if (it.length <= maxLength) onValueChange(it)
                     },
                     enabled = enabled,
-                    singleLine = true,
+                    singleLine = singleLine,
                     textStyle = OnDotTypo().bodyLargeR1.copy(color = OnDotColor.Gray0),
                     keyboardOptions = keyboardOptions,
                     cursorBrush = SolidColor(OnDotColor.Gray0),

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/ui/theme/String.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/ui/theme/String.kt
@@ -23,6 +23,8 @@ const val WORD_HELP = "도움"
 const val WORD_ACCOUNT = "계정"
 const val WORD_WITHDRAW = "회원탈퇴"
 const val WORD_LOGOUT = "로그아웃"
+const val WORD_FINE = "괜찮아요"
+const val WORD_CONFIRM = "확인"
 
 // 알람 카테고리
 const val CATEGORY_GENERAL = "기본"
@@ -89,6 +91,11 @@ const val ROUTE_CALCULATE_LABEL = "최적의 출발 시간이 계산된\n알람�
 const val NEW_SCHEDULE_LABEL = "새로운 일정"
 const val DEPARTURE_ALARM_LABEL = "출발 알람"
 const val PREPARATION_ALARM_LABEL = "준비 알람"
+
+// General/BottomSheet
+const val GENERAL_SCHEDULE_BOTTOM_SHEET_TITLE = "출발 전 챙겨야할 게 있나요?"
+const val GENERAL_SCHEDULE_BOTTOM_SHEET_MEDICINE = "건강에 중요한 약을 챙겨야해요"
+const val GENERAL_SCHEDULE_BOTTOM_SHEET_MATERIAL = "준비물을 적어두면 출발알람이 울릴 때\n알려드려요!"
 
 // Setting
 const val SETTING_HOME_ADDRESS = "집 주소 설정"


### PR DESCRIPTION
## 이슈 번호
- close #33 

## 작업내용
### commonMain
- [x] OnDotBottomSheet 구현
- [x] CheckScheduleScreen: 바텀시트 렌더링 로직 구현
- [x] GeneralScheduleViewModel: 준비물, 약 상태 처리 및 비즈니스 로직 연결
