### PR TITLE
Feat: SQLdelight 데이터베이스 구현

### DIFF
--- a/build-logic/src/main/java/com/ondot/build_logic/ComposeMultiplatformPlugin.kt
+++ b/build-logic/src/main/java/com/ondot/build_logic/ComposeMultiplatformPlugin.kt
@@ -45,6 +45,7 @@ class ComposeMultiplatformPlugin : Plugin<Project> {
                     implementation(libs.findLibrary("kotlinx-io-core").get())
                     implementation(libs.findLibrary("kotlinx-io-bytestring").get())
                     implementation(libs.findLibrary("kotlinx-datetime").get())
+                    implementation(libs.findLibrary("coroutines-extensions").get())
                     implementation("io.insert-koin:koin-core:4.0.3")
                 }
 
@@ -59,12 +60,14 @@ class ComposeMultiplatformPlugin : Plugin<Project> {
                     implementation(libs.findLibrary("datastore-preferences").get())
                     implementation(libs.findLibrary("ktor-client-okhttp").get())
                     implementation(libs.findLibrary("kakao-login").get())
+                    implementation(libs.findLibrary("android-driver").get())
                     implementation("io.insert-koin:koin-android:4.0.3")
                 }
 
                 val iosMain = maybeCreate("iosMain")
                 iosMain.dependencies {
                     implementation(libs.findLibrary("ktor-client-darwin").get())
+                    implementation(libs.findLibrary("native-driver").get())
                 }
             }
         }
@@ -78,17 +81,6 @@ class ComposeMultiplatformPlugin : Plugin<Project> {
                 }
             }
         }
-
-//        project.configurations.configureEach {
-//            resolutionStrategy.eachDependency {
-//                if (requested.group == "org.jetbrains.kotlinx" &&
-//                    (requested.name == "kotlinx-io-core" ||
-//                            requested.name == "kotlinx-io-bytestring")) {
-//                    useVersion("0.3.0")
-//                    because("Align kotlinx-io modules with Ktor requirement")
-//                }
-//            }
-//        }
 
         project.dependencies.add(
             "debugImplementation",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,4 +9,5 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinJvm) apply false
     alias(libs.plugins.composeHotReload) apply false
     alias(libs.plugins.serialization) apply false
+    alias(libs.plugins.sqldelight) apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,4 +10,5 @@ plugins {
     alias(libs.plugins.composeHotReload) apply false
     alias(libs.plugins.serialization) apply false
     alias(libs.plugins.sqldelight) apply false
+    alias(libs.plugins.buildKonfig) apply false
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
 sqldelight {
     databases {
         create("OndotDatabase") {
-            packageName.set("com.ondot.database")
+            packageName.set("com.dh.ondot.data.local.db")
         }
     }
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,7 +1,7 @@
 
+import com.codingfeline.buildkonfig.compiler.FieldSpec.Type
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import com.codingfeline.buildkonfig.compiler.FieldSpec.Type
 import java.util.Properties
 
 plugins {
@@ -13,6 +13,8 @@ plugins {
 
 buildkonfig {
     packageName = "com.dh.ondot"
+
+    exposeObjectWithName = "BuildKonfig"
 
     val props = Properties().apply {
         val file = rootProject.file("local.properties")

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,11 +1,32 @@
 
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import com.codingfeline.buildkonfig.compiler.FieldSpec.Type
+import java.util.Properties
 
 plugins {
     id("ondot.compose.app")
     alias(libs.plugins.composeHotReload)
     alias(libs.plugins.sqldelight)
+    alias(libs.plugins.buildKonfig)
+}
+
+buildkonfig {
+    packageName = "com.dh.ondot"
+
+    val props = Properties().apply {
+        val file = rootProject.file("local.properties")
+        if (file.exists()) file.inputStream().use { load(it) }
+    }
+    val baseUrl = props.getProperty("BASE_URL")
+
+    defaultConfigs {
+        buildConfigField(
+            Type.STRING,
+            "BASE_URL",
+            baseUrl
+        )
+    }
 }
 
 kotlin {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 plugins {
     id("ondot.compose.app")
     alias(libs.plugins.composeHotReload)
+    alias(libs.plugins.sqldelight)
 }
 
 kotlin {
@@ -24,6 +25,14 @@ kotlin {
                 includeDirs.allHeaders(project.rootDir.resolve("iosApp/iosApp"))
                 includeDirs.allHeaders(project.rootDir.resolve("iosApp/ThirdParty/KakaoSDKAuth/Headers"))
             }
+        }
+    }
+}
+
+sqldelight {
+    databases {
+        create("OndotDatabase") {
+            packageName.set("com.ondot.database")
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/app/OnDotApplication.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/app/OnDotApplication.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import com.dh.ondot.BuildConfig
 import com.dh.ondot.core.initKoin
 import com.dh.ondot.core.initShared
-import com.dh.ondot.util.AppContextHolder
+import com.dh.ondot.core.util.AppContextHolder
 import com.kakao.sdk.common.KakaoSdk
 
 class OnDotApplication: Application() {

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/di/PlatformDependencies.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/di/PlatformDependencies.android.kt
@@ -25,7 +25,7 @@ import com.dh.ondot.domain.service.AlarmScheduler
 import com.dh.ondot.domain.service.AlarmStorage
 import com.dh.ondot.domain.service.MapProviderStorage
 import com.dh.ondot.domain.service.SoundPlayer
-import com.dh.ondot.network.TokenProvider
+import com.dh.ondot.core.network.TokenProvider
 import com.dh.ondot.util.AppContextHolder
 
 actual fun provideTokenProvider(): TokenProvider {

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/network/TokenProvider.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/network/TokenProvider.kt
@@ -1,4 +1,4 @@
-package com.dh.ondot.network
+package com.dh.ondot.core.network
 
 import android.content.Context
 import com.dh.ondot.data.OnDotDataStore

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/platform/AppleSignIn.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/platform/AppleSignIn.kt
@@ -1,4 +1,4 @@
-package com.dh.ondot.core.di
+package com.dh.ondot.core.platform
 
 actual fun appleSignIn(
     onSuccess: (identityToken: String?, authorizationCode: String?) -> Unit,

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/platform/DriverFactory.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/platform/DriverFactory.kt
@@ -1,0 +1,10 @@
+package com.dh.ondot.core.platform
+
+import android.content.Context
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+import com.dh.ondot.data.local.db.OndotDatabase
+
+actual class DriverFactory(private val context: Context) {
+    actual fun createDriver(dbName: String): SqlDriver = AndroidSqliteDriver(OndotDatabase.Schema, context, dbName)
+}

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/platform/KakaoSignIn.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/platform/KakaoSignIn.kt
@@ -2,7 +2,7 @@ package com.dh.ondot.core.platform
 
 import android.content.Context
 import android.util.Log
-import com.dh.ondot.util.AppContextHolder
+import com.dh.ondot.core.util.AppContextHolder
 import com.kakao.sdk.user.UserApiClient
 
 actual fun kakaoSignIn(onResult: (String) -> Unit) {

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/platform/KakaoSignIn.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/platform/KakaoSignIn.kt
@@ -1,4 +1,4 @@
-package com.dh.ondot.core.di
+package com.dh.ondot.core.platform
 
 import android.content.Context
 import android.util.Log

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/platform/PlatformDependencies.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/platform/PlatformDependencies.android.kt
@@ -1,4 +1,4 @@
-package com.dh.ondot.core.di
+package com.dh.ondot.core.platform
 
 import android.annotation.SuppressLint
 import android.content.Intent
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.net.toUri
 import co.touchlab.kermit.Logger
+import com.dh.ondot.core.network.TokenProvider
 import com.dh.ondot.core.util.AlarmService
 import com.dh.ondot.core.util.AndroidAlarmScheduler
 import com.dh.ondot.core.util.AndroidAlarmStorage
@@ -25,7 +26,6 @@ import com.dh.ondot.domain.service.AlarmScheduler
 import com.dh.ondot.domain.service.AlarmStorage
 import com.dh.ondot.domain.service.MapProviderStorage
 import com.dh.ondot.domain.service.SoundPlayer
-import com.dh.ondot.core.network.TokenProvider
 import com.dh.ondot.util.AppContextHolder
 
 actual fun provideTokenProvider(): TokenProvider {
@@ -69,8 +69,10 @@ actual fun openDirections(
         MapProvider.APPLE -> error("unreachable")
     }
     val intent = when(provider) {
-        MapProvider.KAKAO -> Intent(Intent.ACTION_VIEW,
-            "kakaomap://route?sp=$startLat,$startLng&ep=$endLat,$endLng&by=$mode".toUri()).apply { `package` = "net.daum.android.map" }
+        MapProvider.KAKAO -> Intent(
+            Intent.ACTION_VIEW,
+            "kakaomap://route?sp=$startLat,$startLng&ep=$endLat,$endLng&by=$mode".toUri()
+        ).apply { `package` = "net.daum.android.map" }
         MapProvider.NAVER -> Intent(Intent.ACTION_VIEW, ("nmap://route/$mode" +
                 "?slat=$startLat&slng=$startLng&sname=${Uri.encode(startName)}" +
                 "&dlat=$endLat&dlng=$endLng&dname=${Uri.encode(endName)}" +

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/platform/PlatformDependencies.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/platform/PlatformDependencies.android.kt
@@ -21,12 +21,14 @@ import com.dh.ondot.core.util.AndroidAlarmScheduler
 import com.dh.ondot.core.util.AndroidAlarmStorage
 import com.dh.ondot.core.util.AndroidMapProviderStorage
 import com.dh.ondot.core.util.AndroidSoundPlayer
+import com.dh.ondot.core.util.AppContextHolder
+import com.dh.ondot.data.local.db.DatabaseFactory
+import com.dh.ondot.data.local.db.OndotDatabase
 import com.dh.ondot.domain.model.enums.MapProvider
 import com.dh.ondot.domain.service.AlarmScheduler
 import com.dh.ondot.domain.service.AlarmStorage
 import com.dh.ondot.domain.service.MapProviderStorage
 import com.dh.ondot.domain.service.SoundPlayer
-import com.dh.ondot.core.util.AppContextHolder
 
 actual fun provideTokenProvider(): TokenProvider {
     val context = runCatching { AppContextHolder.context }
@@ -50,6 +52,12 @@ actual fun provideAlarmScheduler(): AlarmScheduler {
     val context = runCatching { AppContextHolder.context }
         .getOrElse { error("AppContextHolder.context가 아직 초기화되지 않았습니다.") }
     return AndroidAlarmScheduler(context)
+}
+
+actual fun provideDatabase(): OndotDatabase {
+    val context = runCatching { AppContextHolder.context }
+        .getOrElse { error("AppContextHolder.context가 아직 초기화되지 않았습니다.") }
+    return DatabaseFactory(DriverFactory(context)).create()
 }
 
 actual fun openDirections(

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/platform/PlatformDependencies.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/platform/PlatformDependencies.android.kt
@@ -26,7 +26,7 @@ import com.dh.ondot.domain.service.AlarmScheduler
 import com.dh.ondot.domain.service.AlarmStorage
 import com.dh.ondot.domain.service.MapProviderStorage
 import com.dh.ondot.domain.service.SoundPlayer
-import com.dh.ondot.util.AppContextHolder
+import com.dh.ondot.core.util.AppContextHolder
 
 actual fun provideTokenProvider(): TokenProvider {
     val context = runCatching { AppContextHolder.context }

--- a/composeApp/src/androidMain/kotlin/com/dh/ondot/core/util/AppContextHolder.kt
+++ b/composeApp/src/androidMain/kotlin/com/dh/ondot/core/util/AppContextHolder.kt
@@ -1,4 +1,4 @@
-package com.dh.ondot.util
+package com.dh.ondot.core.util
 
 import android.app.Application
 import android.content.Context

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/SharedInit.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/SharedInit.kt
@@ -4,6 +4,7 @@ import com.dh.ondot.core.di.ServiceLocator
 import com.dh.ondot.core.platform.appModule
 import com.dh.ondot.core.platform.provideAlarmScheduler
 import com.dh.ondot.core.platform.provideAlarmStorage
+import com.dh.ondot.core.platform.provideDatabase
 import com.dh.ondot.core.platform.provideMapProvider
 import com.dh.ondot.core.platform.provideSoundPlayer
 import com.dh.ondot.core.platform.provideTokenProvider
@@ -15,7 +16,8 @@ fun initShared() {
         provideAlarmStorage(),
         provideAlarmScheduler(),
         provideSoundPlayer(),
-        provideMapProvider()
+        provideMapProvider(),
+        provideDatabase()
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/SharedInit.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/SharedInit.kt
@@ -1,12 +1,12 @@
 package com.dh.ondot.core
 
 import com.dh.ondot.core.di.ServiceLocator
-import com.dh.ondot.core.di.appModule
-import com.dh.ondot.core.di.provideAlarmScheduler
-import com.dh.ondot.core.di.provideAlarmStorage
-import com.dh.ondot.core.di.provideMapProvider
-import com.dh.ondot.core.di.provideSoundPlayer
-import com.dh.ondot.core.di.provideTokenProvider
+import com.dh.ondot.core.platform.appModule
+import com.dh.ondot.core.platform.provideAlarmScheduler
+import com.dh.ondot.core.platform.provideAlarmStorage
+import com.dh.ondot.core.platform.provideMapProvider
+import com.dh.ondot.core.platform.provideSoundPlayer
+import com.dh.ondot.core.platform.provideTokenProvider
 import org.koin.core.context.startKoin
 
 fun initShared() {

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/di/AppModule.kt
@@ -6,8 +6,8 @@ import com.dh.ondot.data.repository.ScheduleRepositoryImpl
 import com.dh.ondot.domain.repository.MemberRepository
 import com.dh.ondot.domain.repository.PlaceRepository
 import com.dh.ondot.domain.repository.ScheduleRepository
-import com.dh.ondot.network.NetworkClient
-import com.dh.ondot.network.TokenProvider
+import com.dh.ondot.core.network.NetworkClient
+import com.dh.ondot.core.network.TokenProvider
 import org.koin.core.module.Module
 import org.koin.dsl.module
 

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/di/PlatformDependencies.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/di/PlatformDependencies.kt
@@ -7,7 +7,7 @@ import com.dh.ondot.domain.service.AlarmScheduler
 import com.dh.ondot.domain.service.AlarmStorage
 import com.dh.ondot.domain.service.MapProviderStorage
 import com.dh.ondot.domain.service.SoundPlayer
-import com.dh.ondot.network.TokenProvider
+import com.dh.ondot.core.network.TokenProvider
 
 expect fun provideTokenProvider(): TokenProvider
 

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/di/ServiceLocator.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/di/ServiceLocator.kt
@@ -1,9 +1,14 @@
 package com.dh.ondot.core.di
 
+import com.dh.ondot.core.network.NetworkClient
+import com.dh.ondot.core.network.TokenProvider
+import com.dh.ondot.data.local.datasource.ScheduleLocalDataSourceImpl
+import com.dh.ondot.data.local.db.OndotDatabase
 import com.dh.ondot.data.repository.AuthRepositoryImpl
 import com.dh.ondot.data.repository.MemberRepositoryImpl
 import com.dh.ondot.data.repository.PlaceRepositoryImpl
 import com.dh.ondot.data.repository.ScheduleRepositoryImpl
+import com.dh.ondot.domain.datasource.ScheduleLocalDataSource
 import com.dh.ondot.domain.repository.AuthRepository
 import com.dh.ondot.domain.repository.MemberRepository
 import com.dh.ondot.domain.repository.PlaceRepository
@@ -12,8 +17,6 @@ import com.dh.ondot.domain.service.AlarmScheduler
 import com.dh.ondot.domain.service.AlarmStorage
 import com.dh.ondot.domain.service.MapProviderStorage
 import com.dh.ondot.domain.service.SoundPlayer
-import com.dh.ondot.core.network.NetworkClient
-import com.dh.ondot.core.network.TokenProvider
 
 object ServiceLocator {
     private lateinit var tokenProvider: TokenProvider
@@ -22,6 +25,7 @@ object ServiceLocator {
     private lateinit var alarmScheduler: AlarmScheduler
     private lateinit var soundPlayer: SoundPlayer
     private lateinit var mapProviderStorage: MapProviderStorage
+    private lateinit var database: OndotDatabase
 
     val authRepository: AuthRepository by lazy {
         AuthRepositoryImpl(networkClient, tokenProvider)
@@ -36,7 +40,11 @@ object ServiceLocator {
     }
 
     val scheduleRepository: ScheduleRepository by lazy {
-        ScheduleRepositoryImpl(networkClient)
+        ScheduleRepositoryImpl(networkClient, scheduleLocalDataSource)
+    }
+
+    val scheduleLocalDataSource: ScheduleLocalDataSource by lazy {
+        ScheduleLocalDataSourceImpl(database)
     }
 
     fun init(
@@ -44,7 +52,8 @@ object ServiceLocator {
         alarmStorage: AlarmStorage,
         alarmScheduler: AlarmScheduler,
         soundPlayer: SoundPlayer,
-        mapProviderStorage: MapProviderStorage
+        mapProviderStorage: MapProviderStorage,
+        database: OndotDatabase
     ) {
         this.tokenProvider = tokenProvider
         this.networkClient = NetworkClient(tokenProvider)
@@ -52,6 +61,7 @@ object ServiceLocator {
         this.alarmScheduler = alarmScheduler
         this.soundPlayer = soundPlayer
         this.mapProviderStorage = mapProviderStorage
+        this.database = database
     }
 
     fun provideNetworkClient(): NetworkClient = networkClient
@@ -60,5 +70,5 @@ object ServiceLocator {
     fun provideAlarmScheduler(): AlarmScheduler = alarmScheduler
     fun provideSoundPlayer(): SoundPlayer = soundPlayer
     fun provideMapProviderStorage(): MapProviderStorage = mapProviderStorage
-
+    fun provideDatabase(): OndotDatabase = database
 }

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/di/ServiceLocator.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/di/ServiceLocator.kt
@@ -12,8 +12,8 @@ import com.dh.ondot.domain.service.AlarmScheduler
 import com.dh.ondot.domain.service.AlarmStorage
 import com.dh.ondot.domain.service.MapProviderStorage
 import com.dh.ondot.domain.service.SoundPlayer
-import com.dh.ondot.network.NetworkClient
-import com.dh.ondot.network.TokenProvider
+import com.dh.ondot.core.network.NetworkClient
+import com.dh.ondot.core.network.TokenProvider
 
 object ServiceLocator {
     private lateinit var tokenProvider: TokenProvider

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/BaseRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/BaseRepository.kt
@@ -15,14 +15,18 @@ abstract class BaseRepository(
         val client = network
 
         return retryResult(retries = retries) {
-            client.request<T>(
-                path = path,
-                method = method,
-                body = body,
-                queryParams = query,
-                addAuthHeader = addAuthHeader,
-                isReissue = isReissue
-            )
+            try {
+                client.request<T>(
+                    path = path,
+                    method = method,
+                    body = body,
+                    queryParams = query,
+                    addAuthHeader = addAuthHeader,
+                    isReissue = isReissue
+                )
+            } catch (t: Throwable) {
+                Result.failure(t)
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/BaseRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/BaseRepository.kt
@@ -11,14 +11,18 @@ abstract class BaseRepository(
         addAuthHeader: Boolean = true,
         retries: Int = 0,
         isReissue: Boolean = false
-    ): Result<T> = retryResult(retries = retries) {
-        network.request<T>(
-            path = path,
-            method = method,
-            body = body,
-            queryParams = query,
-            addAuthHeader = addAuthHeader,
-            isReissue = isReissue
-        )
+    ): Result<T> {
+        val client = network
+
+        return retryResult(retries = retries) {
+            client.request<T>(
+                path = path,
+                method = method,
+                body = body,
+                queryParams = query,
+                addAuthHeader = addAuthHeader,
+                isReissue = isReissue
+            )
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/BaseRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/BaseRepository.kt
@@ -1,0 +1,24 @@
+package com.dh.ondot.core.network
+
+abstract class BaseRepository(
+    protected val network: NetworkClient
+) {
+    protected suspend inline fun <reified T> fetch(
+        method: HttpMethod,
+        path: String,
+        body: Any? = null,
+        query: Map<String, String> = emptyMap(),
+        addAuthHeader: Boolean = true,
+        retries: Int = 0,
+        isReissue: Boolean = false
+    ): Result<T> = retryResult(retries = retries) {
+        network.request<T>(
+            path = path,
+            method = method,
+            body = body,
+            queryParams = query,
+            addAuthHeader = addAuthHeader,
+            isReissue = isReissue
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/DefaultOnNullLongSerializer.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/DefaultOnNullLongSerializer.kt
@@ -1,4 +1,4 @@
-package com.dh.ondot.network
+package com.dh.ondot.core.network
 
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/HttpMethod.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/HttpMethod.kt
@@ -1,4 +1,4 @@
-package com.dh.ondot.network
+package com.dh.ondot.core.network
 
 enum class HttpMethod {
     GET, POST, PUT, PATCH, DELETE

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/NetworkClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/NetworkClient.kt
@@ -1,5 +1,6 @@
 package com.dh.ondot.core.network
 
+import com.dh.ondot.BuildKonfig
 import com.dh.ondot.core.di.httpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.header
@@ -20,7 +21,7 @@ class NetworkClient(
         isReissue: Boolean = false
     ): Result<T> {
         return try {
-            val response = httpClient.request("$BASE_URL$path") {
+            val response = httpClient.request("${BuildKonfig.BASE_URL}$path") {
                 this.method = when (method) {
                     HttpMethod.GET -> io.ktor.http.HttpMethod.Get
                     HttpMethod.POST -> io.ktor.http.HttpMethod.Post

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/NetworkClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/NetworkClient.kt
@@ -14,18 +14,13 @@ class NetworkClient(
     suspend inline fun <reified T> request(
         method: HttpMethod,
         path: String,
-        pathParams: Map<String, Any> = emptyMap(),
         queryParams: Map<String, Any> = emptyMap(),
         body: Any? = null,
         addAuthHeader: Boolean = true,
         isReissue: Boolean = false
     ): Result<T> {
         return try {
-            val resolvedPath = pathParams.entries.fold(path) { acc, (key, value) ->
-                acc.replace("{$key}", value.toString())
-            }
-
-            val response = httpClient.request("$BASE_URL$resolvedPath") {
+            val response = httpClient.request("$BASE_URL$path") {
                 this.method = when (method) {
                     HttpMethod.GET -> io.ktor.http.HttpMethod.Get
                     HttpMethod.POST -> io.ktor.http.HttpMethod.Post

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/NetworkClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/NetworkClient.kt
@@ -1,4 +1,4 @@
-package com.dh.ondot.network
+package com.dh.ondot.core.network
 
 import com.dh.ondot.core.di.httpClient
 import io.ktor.client.call.body

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/NetworkConfig.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/NetworkConfig.kt
@@ -1,0 +1,3 @@
+package com.dh.ondot.core.network
+
+const val BASE_URL = "https://on-dot.site"

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/NetworkConfig.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/NetworkConfig.kt
@@ -1,3 +1,0 @@
-package com.dh.ondot.core.network
-
-const val BASE_URL = "https://on-dot.site"

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/Retry.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/Retry.kt
@@ -1,0 +1,22 @@
+package com.dh.ondot.core.network
+
+import kotlinx.coroutines.delay
+
+
+suspend fun <T> retryResult(
+    retries: Int = 0,
+    initialDelayMs: Long = 300,
+    maxDelayMs: Long = 5_000,
+    factor: Double = 2.0,
+    block: suspend () -> Result<T>
+): Result<T> {
+    var attempt = 0
+    var delayMs = initialDelayMs
+    while (true) {
+        val result = block()
+        if (result.isSuccess || attempt >= retries) return result
+        attempt++
+        delay(delayMs)
+        delayMs = (delayMs * factor).toLong().coerceAtMost(maxDelayMs)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/TokenProvider.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/network/TokenProvider.kt
@@ -1,4 +1,4 @@
-package com.dh.ondot.network
+package com.dh.ondot.core.network
 
 import com.dh.ondot.data.model.TokenModel
 

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/platform/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/platform/AppModule.kt
@@ -14,7 +14,7 @@ import org.koin.dsl.module
 val appModule: Module = module {
     single<TokenProvider> { provideTokenProvider() }
     single { NetworkClient(get()) }
-    single<ScheduleRepository> { ScheduleRepositoryImpl(get()) }
+    single<ScheduleRepository> { ScheduleRepositoryImpl(get(), get()) }
     single<PlaceRepository> { PlaceRepositoryImpl(get()) }
     single<MemberRepository> { MemberRepositoryImpl(get(), get()) }
 }

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/platform/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/platform/AppModule.kt
@@ -1,13 +1,13 @@
-package com.dh.ondot.core.di
+package com.dh.ondot.core.platform
 
+import com.dh.ondot.core.network.NetworkClient
+import com.dh.ondot.core.network.TokenProvider
 import com.dh.ondot.data.repository.MemberRepositoryImpl
 import com.dh.ondot.data.repository.PlaceRepositoryImpl
 import com.dh.ondot.data.repository.ScheduleRepositoryImpl
 import com.dh.ondot.domain.repository.MemberRepository
 import com.dh.ondot.domain.repository.PlaceRepository
 import com.dh.ondot.domain.repository.ScheduleRepository
-import com.dh.ondot.core.network.NetworkClient
-import com.dh.ondot.core.network.TokenProvider
 import org.koin.core.module.Module
 import org.koin.dsl.module
 

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/platform/AppleSignIn.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/platform/AppleSignIn.kt
@@ -1,4 +1,4 @@
-package com.dh.ondot.core.di
+package com.dh.ondot.core.platform
 
 expect fun appleSignIn(
     onSuccess: (identityToken: String?, authorizationCode: String?) -> Unit,

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/platform/DriverFactory.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/platform/DriverFactory.kt
@@ -1,0 +1,8 @@
+package com.dh.ondot.core.platform
+
+import app.cash.sqldelight.db.SqlDriver
+import com.dh.ondot.presentation.ui.theme.DATABASE_NAME
+
+expect class DriverFactory {
+    fun createDriver(dbName: String = DATABASE_NAME): SqlDriver
+}

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/platform/KakaoSignIn.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/platform/KakaoSignIn.kt
@@ -1,3 +1,3 @@
-package com.dh.ondot.core.di
+package com.dh.ondot.core.platform
 
 expect fun kakaoSignIn(onResult: (String) -> Unit)

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/platform/PlatformDependencies.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/platform/PlatformDependencies.kt
@@ -3,6 +3,7 @@ package com.dh.ondot.core.platform
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.dh.ondot.core.network.TokenProvider
+import com.dh.ondot.data.local.db.OndotDatabase
 import com.dh.ondot.domain.model.enums.MapProvider
 import com.dh.ondot.domain.service.AlarmScheduler
 import com.dh.ondot.domain.service.AlarmStorage
@@ -16,6 +17,8 @@ expect fun provideSoundPlayer(): SoundPlayer
 expect fun provideAlarmStorage(): AlarmStorage
 
 expect fun provideAlarmScheduler(): AlarmScheduler
+
+expect fun provideDatabase(): OndotDatabase
 
 expect fun openDirections(
     startLat: Double,

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/core/platform/PlatformDependencies.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/core/platform/PlatformDependencies.kt
@@ -1,13 +1,13 @@
-package com.dh.ondot.core.di
+package com.dh.ondot.core.platform
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.dh.ondot.core.network.TokenProvider
 import com.dh.ondot.domain.model.enums.MapProvider
 import com.dh.ondot.domain.service.AlarmScheduler
 import com.dh.ondot.domain.service.AlarmStorage
 import com.dh.ondot.domain.service.MapProviderStorage
 import com.dh.ondot.domain.service.SoundPlayer
-import com.dh.ondot.core.network.TokenProvider
 
 expect fun provideTokenProvider(): TokenProvider
 

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/data/local/datasource/ScheduleLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/data/local/datasource/ScheduleLocalDataSourceImpl.kt
@@ -1,0 +1,102 @@
+package com.dh.ondot.data.local.datasource
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import com.dh.ondot.data.local.db.OndotDatabase
+import com.dh.ondot.data.local.db.ScheduleEntityQueries
+import com.dh.ondot.data.local.db.toDomain
+import com.dh.ondot.domain.datasource.ScheduleLocalDataSource
+import com.dh.ondot.domain.model.response.Schedule
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+class ScheduleLocalDataSourceImpl(
+    private val db: OndotDatabase
+): ScheduleLocalDataSource {
+    private val q = db.scheduleEntityQueries
+
+    /**
+     * 쿼리 결과 변환 과정
+     * 1. getAll(): Query<ScheduleEntity>
+     * 2. asFlow(): Flow<Query<ScheduleEntity>>
+     * 3. mapToList(IO): Flow<List<ScheduleEntity>>
+     * 4. map { it.toDomain }: Flow<List<Schedule>>
+     * */
+    override fun observeList(): Flow<List<Schedule>> =
+        q.getAll()
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { list -> list.map { it.toDomain() } }
+
+    /**
+     * mapToList, mapToOneOrNull 과 같은 코루틴 확장 함수는 내부적으로는 execute..() 형태의 blocking 메서드를 호출하지만
+     * Flow 수집 시점에 blocking 쿼리 실행이 이루어지도록 보장해줌
+     * 쉽게 말하자면 SQLDelight가 대신 withContext(Dispatchers.IO)를 처리해주는 형태
+     * 파라미터로 넘겨주는 Dispatcher를 내부적으로 실행시켜줌
+     * */
+    override fun observeById(id: Long): Flow<Schedule?> =
+        q.getById(id)
+            .asFlow()
+            .mapToOneOrNull(Dispatchers.IO)
+            .map { entity -> entity?.toDomain() }
+
+    /**
+     * executeAsOneOrNull() -> SQLDelight에서 단일 행을 즉시 가져오는 메서드
+     * executeAsOneOrNull은 block api이기 때문에 호출한 스레드를 차단해버림. 메인 스레드에서 실행할 경우 ANR 발생 위험 높음
+     * withContext(Dispatchers.IO) -> IO 스레드에서 실행. 메인 스레드를 차단하지 않음
+     * */
+    override suspend fun getByIdOnce(id: Long): Schedule? =
+        withContext(Dispatchers.IO) {
+            q.getById(id).executeAsOneOrNull()?.toDomain()
+        }
+
+    /**
+     * transaction {} 내부는 Blocking API이므로 withContext(Dispatchers.IO)로 IO 스레드에서 실행
+     * 반복문을 실행할 때 forEach는 inline lambda라서 I/O가 많아질 때 불필요한 람다 객체 생성을 유발할 수 있음
+     * 단순 반복은 for 루프가 조금 더 효율적인 편
+     * */
+    override suspend fun upsertAll(items: List<Schedule>) = withContext(Dispatchers.IO) {
+        db.transaction {
+            for (item in items) {
+                q.upsertSchedule(item)
+            }
+        }
+    }
+
+    override suspend fun upsert(item: Schedule) = withContext(Dispatchers.IO) {
+        q.upsertSchedule(item)
+    }
+
+    private fun ScheduleEntityQueries.upsertSchedule(item: Schedule) {
+        upsert(
+            scheduleId = item.scheduleId,
+            startLongitude = item.startLongitude,
+            startLatitude = item.startLatitude,
+            endLongitude = item.endLongitude,
+            endLatitude = item.endLatitude,
+            scheduleTitle = item.scheduleTitle,
+            isRepeat = item.isRepeat,
+            repeatDays = item.repeatDays,
+            appointmentAt = item.appointmentAt,
+            preparationAlarm = item.preparationAlarm,
+            departureAlarm = item.departureAlarm,
+            hasActiveAlarm = item.hasActiveAlarm
+        )
+    }
+
+    override suspend fun deleteById(id: Long) {
+        withContext(Dispatchers.IO) {
+            q.deleteById(id)
+        }
+    }
+
+    override suspend fun clear() {
+        withContext(Dispatchers.IO) {
+            q.clear()
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/data/local/db/Adapters.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/data/local/db/Adapters.kt
@@ -1,0 +1,35 @@
+package com.dh.ondot.data.local.db
+
+import app.cash.sqldelight.ColumnAdapter
+import com.dh.ondot.domain.model.response.AlarmDetail
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+// 기본값 포함
+// 알 수 없는 필드 무시
+private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+}
+
+// Boolean <-> INTEGER(0/1)
+object BooleanAsIntAdapter : ColumnAdapter<Boolean, Long> {
+    override fun decode(databaseValue: Long): Boolean = databaseValue != 0L
+    override fun encode(value: Boolean): Long = if (value) 1L else 0L
+}
+
+// List<Int> <-> Text(Json)
+object IntListAsJsonAdapter : ColumnAdapter<List<Int>, String> {
+    private val serializer = ListSerializer(Int.serializer())
+
+    override fun decode(databaseValue: String): List<Int> = json.decodeFromString(serializer, databaseValue)
+    override fun encode(value: List<Int>): String = json.encodeToString(serializer, value)
+}
+
+// AlarmDetail <-> TEXT(JSON)
+object AlarmDetailAsJsonAdapter : ColumnAdapter<AlarmDetail, String> {
+    override fun decode(databaseValue: String): AlarmDetail = json.decodeFromString(databaseValue)
+    override fun encode(value: AlarmDetail): String = json.encodeToString(value)
+}

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/data/local/db/DatabaseFactory.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/data/local/db/DatabaseFactory.kt
@@ -1,0 +1,19 @@
+package com.dh.ondot.data.local.db
+
+import com.dh.ondot.core.platform.DriverFactory
+import com.dh.ondot.presentation.ui.theme.DATABASE_NAME
+
+class DatabaseFactory(private val driverFactory: DriverFactory) {
+    fun create(): OndotDatabase {
+        val driver = driverFactory.createDriver(DATABASE_NAME)
+
+        return OndotDatabase(
+            driver,
+            Schedule_entity.Adapter(
+                repeatDaysAdapter = IntListAsJsonAdapter,
+                preparationAlarmAdapter = AlarmDetailAsJsonAdapter,
+                departureAlarmAdapter = AlarmDetailAsJsonAdapter,
+            )
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/data/local/db/Mappers.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/data/local/db/Mappers.kt
@@ -1,0 +1,34 @@
+package com.dh.ondot.data.local.db
+
+import com.dh.ondot.domain.model.response.Schedule
+
+fun Schedule_entity.toDomain(): Schedule =
+    Schedule(
+        scheduleId       = scheduleId,
+        startLongitude   = startLongitude,
+        startLatitude    = startLatitude,
+        endLongitude     = endLongitude,
+        endLatitude      = endLatitude,
+        scheduleTitle    = scheduleTitle,
+        isRepeat         = isRepeat,
+        repeatDays       = repeatDays,
+        appointmentAt    = appointmentAt,
+        preparationAlarm = preparationAlarm,
+        departureAlarm   = departureAlarm,
+        hasActiveAlarm   = hasActiveAlarm
+    )
+
+fun Schedule.toEntity() = Schedule_entity(
+    scheduleId       = scheduleId,
+    startLongitude   = startLongitude,
+    startLatitude    = startLatitude,
+    endLongitude     = endLongitude,
+    endLatitude      = endLatitude,
+    scheduleTitle    = scheduleTitle,
+    isRepeat         = isRepeat,
+    repeatDays       = repeatDays,
+    appointmentAt    = appointmentAt,
+    preparationAlarm = preparationAlarm,
+    departureAlarm   = departureAlarm,
+    hasActiveAlarm   = hasActiveAlarm
+)

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/data/repository/AuthRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/data/repository/AuthRepositoryImpl.kt
@@ -1,41 +1,34 @@
 package com.dh.ondot.data.repository
 
-import com.dh.ondot.data.model.TokenModel
-import com.dh.ondot.domain.model.response.AuthResponse
-import com.dh.ondot.domain.repository.AuthRepository
+import com.dh.ondot.core.network.BaseRepository
 import com.dh.ondot.core.network.HttpMethod
 import com.dh.ondot.core.network.NetworkClient
 import com.dh.ondot.core.network.TokenProvider
+import com.dh.ondot.data.model.TokenModel
+import com.dh.ondot.domain.model.response.AuthResponse
+import com.dh.ondot.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 class AuthRepositoryImpl(
-    private val networkClient: NetworkClient,
+    networkClient: NetworkClient,
     private val tokenProvider: TokenProvider
-): AuthRepository {
+): AuthRepository, BaseRepository(networkClient) {
     override suspend fun login(provider: String, accessToken: String): Flow<Result<AuthResponse>> = flow {
-        val response = networkClient.request<AuthResponse>(
-            method = HttpMethod.POST,
-            path = "/auth/login/oauth",
-            queryParams = mapOf("provider" to provider, "access_token" to accessToken)
+        emit(
+            fetch(
+                method = HttpMethod.POST,
+                path = "/auth/login/oauth",
+                query = mapOf(
+                    "provider" to provider,
+                    "access_token" to accessToken
+                )
+            )
         )
-
-        emit(response.fold(
-            onSuccess = { Result.success(it) },
-            onFailure = { Result.failure(it) }
-        ))
     }
 
     override suspend fun logout(): Flow<Result<Unit>> = flow {
-        val response = networkClient.request<Unit>(
-            method = HttpMethod.POST,
-            path = "/auth/logout"
-        )
-
-        emit(response.fold(
-            onSuccess = { Result.success(it) },
-            onFailure = { Result.failure(it) }
-        ))
+        emit(fetch(HttpMethod.POST, "/auth/logout"))
     }
 
     override suspend fun saveToken(token: TokenModel) {
@@ -43,15 +36,12 @@ class AuthRepositoryImpl(
     }
 
     override suspend fun reissueToken(): Flow<Result<TokenModel>> = flow {
-        val response = networkClient.request<TokenModel>(
-            method = HttpMethod.POST,
-            path = "/auth/reissue",
-            isReissue = true
+        emit(
+            fetch(
+                method = HttpMethod.POST,
+                path = "/auth/reissue",
+                isReissue = true
+            )
         )
-
-        emit(response.fold(
-            onSuccess = { Result.success(it) },
-            onFailure = { Result.failure(it) }
-        ))
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/data/repository/AuthRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/data/repository/AuthRepositoryImpl.kt
@@ -3,9 +3,9 @@ package com.dh.ondot.data.repository
 import com.dh.ondot.data.model.TokenModel
 import com.dh.ondot.domain.model.response.AuthResponse
 import com.dh.ondot.domain.repository.AuthRepository
-import com.dh.ondot.network.HttpMethod
-import com.dh.ondot.network.NetworkClient
-import com.dh.ondot.network.TokenProvider
+import com.dh.ondot.core.network.HttpMethod
+import com.dh.ondot.core.network.NetworkClient
+import com.dh.ondot.core.network.TokenProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/data/repository/MemberRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/data/repository/MemberRepositoryImpl.kt
@@ -10,8 +10,8 @@ import com.dh.ondot.domain.model.request.settings.preparation_time.PreparationTi
 import com.dh.ondot.domain.model.response.HomeAddressInfo
 import com.dh.ondot.domain.repository.MemberRepository
 import com.dh.ondot.domain.service.MapProviderStorage
-import com.dh.ondot.network.HttpMethod
-import com.dh.ondot.network.NetworkClient
+import com.dh.ondot.core.network.HttpMethod
+import com.dh.ondot.core.network.NetworkClient
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/data/repository/PlaceRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/data/repository/PlaceRepositoryImpl.kt
@@ -2,8 +2,8 @@ package com.dh.ondot.data.repository
 
 import com.dh.ondot.domain.model.response.AddressInfo
 import com.dh.ondot.domain.repository.PlaceRepository
-import com.dh.ondot.network.HttpMethod
-import com.dh.ondot.network.NetworkClient
+import com.dh.ondot.core.network.HttpMethod
+import com.dh.ondot.core.network.NetworkClient
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/data/repository/PlaceRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/data/repository/PlaceRepositoryImpl.kt
@@ -1,25 +1,23 @@
 package com.dh.ondot.data.repository
 
-import com.dh.ondot.domain.model.response.AddressInfo
-import com.dh.ondot.domain.repository.PlaceRepository
+import com.dh.ondot.core.network.BaseRepository
 import com.dh.ondot.core.network.HttpMethod
 import com.dh.ondot.core.network.NetworkClient
+import com.dh.ondot.domain.model.response.AddressInfo
+import com.dh.ondot.domain.repository.PlaceRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 class PlaceRepositoryImpl(
-    private val networkClient: NetworkClient
-): PlaceRepository {
+    networkClient: NetworkClient
+): PlaceRepository, BaseRepository(networkClient) {
     override suspend fun searchPlace(query: String): Flow<Result<List<AddressInfo>>> = flow {
-        val response = networkClient.request<List<AddressInfo>>(
-            method = HttpMethod.GET,
-            path = "/places/search",
-            queryParams = mapOf("query" to query)
+        emit(
+            fetch(
+                method = HttpMethod.GET,
+                path = "/places/search",
+                query = mapOf("query" to query)
+            )
         )
-
-        emit(response.fold(
-            onSuccess = { Result.success(it) },
-            onFailure = { Result.failure(it) }
-        ))
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/data/repository/ScheduleRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/data/repository/ScheduleRepositoryImpl.kt
@@ -7,8 +7,8 @@ import com.dh.ondot.domain.model.response.ScheduleAlarmResponse
 import com.dh.ondot.domain.model.response.ScheduleDetail
 import com.dh.ondot.domain.model.response.ScheduleListResponse
 import com.dh.ondot.domain.repository.ScheduleRepository
-import com.dh.ondot.network.HttpMethod
-import com.dh.ondot.network.NetworkClient
+import com.dh.ondot.core.network.HttpMethod
+import com.dh.ondot.core.network.NetworkClient
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/domain/datasource/ScheduleLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/domain/datasource/ScheduleLocalDataSource.kt
@@ -1,0 +1,14 @@
+package com.dh.ondot.domain.datasource
+
+import com.dh.ondot.domain.model.response.Schedule
+import kotlinx.coroutines.flow.Flow
+
+interface ScheduleLocalDataSource {
+    fun observeList(): Flow<List<Schedule>>                // 전체 조회
+    fun observeById(id: Long): Flow<Schedule?>             // 단일 조회
+    suspend fun getByIdOnce(id: Long): Schedule?           // 단발 조회
+    suspend fun upsertAll(items: List<Schedule>)
+    suspend fun upsert(item: Schedule)
+    suspend fun deleteById(id: Long)
+    suspend fun clear()
+}

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/domain/model/response/AlarmDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/domain/model/response/AlarmDetail.kt
@@ -1,7 +1,7 @@
 package com.dh.ondot.domain.model.response
 
 import com.dh.ondot.domain.model.enums.AlarmMode
-import com.dh.ondot.network.DefaultOnNullLongSerializer
+import com.dh.ondot.core.network.DefaultOnNullLongSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/domain/repository/ScheduleRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/domain/repository/ScheduleRepository.kt
@@ -3,6 +3,7 @@ package com.dh.ondot.domain.repository
 import com.dh.ondot.domain.model.request.CreateScheduleRequest
 import com.dh.ondot.domain.model.request.ScheduleAlarmRequest
 import com.dh.ondot.domain.model.request.ToggleAlarmRequest
+import com.dh.ondot.domain.model.response.Schedule
 import com.dh.ondot.domain.model.response.ScheduleAlarmResponse
 import com.dh.ondot.domain.model.response.ScheduleDetail
 import com.dh.ondot.domain.model.response.ScheduleListResponse
@@ -16,4 +17,5 @@ interface ScheduleRepository {
     suspend fun deleteSchedule(scheduleId: Long): Flow<Result<Unit>>
     suspend fun editSchedule(scheduleId: Long, request: ScheduleDetail): Flow<Result<Unit>>
     suspend fun toggleAlarm(scheduleId: Long, request: ToggleAlarmRequest): Flow<Result<Unit>>
+    suspend fun getLocalScheduleById(scheduleId: Long): Flow<Schedule?>
 }

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/app/AppViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/app/AppViewModel.kt
@@ -3,8 +3,8 @@ package com.dh.ondot.presentation.app
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.dh.ondot.core.di.ServiceLocator
-import com.dh.ondot.core.di.openDirections
-import com.dh.ondot.core.di.stopService
+import com.dh.ondot.core.platform.openDirections
+import com.dh.ondot.core.platform.stopService
 import com.dh.ondot.core.ui.base.BaseViewModel
 import com.dh.ondot.core.util.DateTimeFormatter
 import com.dh.ondot.core.util.DateTimeFormatter.plusMinutes

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/general/place/PlacePickerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/general/place/PlacePickerScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.dh.ondot.core.di.BackPressHandler
+import com.dh.ondot.core.platform.BackPressHandler
 import com.dh.ondot.domain.model.enums.ButtonType
 import com.dh.ondot.domain.model.enums.OnDotTextStyle
 import com.dh.ondot.domain.model.enums.RouterType

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/login/LoginViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/login/LoginViewModel.kt
@@ -3,8 +3,8 @@ package com.dh.ondot.presentation.login
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.dh.ondot.core.di.ServiceLocator
-import com.dh.ondot.core.di.appleSignIn
-import com.dh.ondot.core.di.kakaoSignIn
+import com.dh.ondot.core.platform.appleSignIn
+import com.dh.ondot.core.platform.kakaoSignIn
 import com.dh.ondot.core.ui.base.BaseViewModel
 import com.dh.ondot.core.ui.base.UiState
 import com.dh.ondot.core.ui.util.ToastManager

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/onboarding/OnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/onboarding/OnboardingScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.dh.ondot.core.di.BackPressHandler
+import com.dh.ondot.core.platform.BackPressHandler
 import com.dh.ondot.domain.model.enums.ButtonType
 import com.dh.ondot.domain.model.response.AddressInfo
 import com.dh.ondot.getPlatform

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/onboarding/OnboardingViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/onboarding/OnboardingViewModel.kt
@@ -16,7 +16,7 @@ import com.dh.ondot.domain.model.response.AddressInfo
 import com.dh.ondot.domain.repository.MemberRepository
 import com.dh.ondot.domain.repository.PlaceRepository
 import com.dh.ondot.domain.service.SoundPlayer
-import com.dh.ondot.network.TokenProvider
+import com.dh.ondot.core.network.TokenProvider
 import kotlinx.coroutines.launch
 
 class OnboardingViewModel(

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/onboarding/OnboardingViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/onboarding/OnboardingViewModel.kt
@@ -2,7 +2,7 @@ package com.dh.ondot.presentation.onboarding
 
 import androidx.lifecycle.viewModelScope
 import com.dh.ondot.core.di.ServiceLocator
-import com.dh.ondot.core.di.provideSoundPlayer
+import com.dh.ondot.core.platform.provideSoundPlayer
 import com.dh.ondot.core.ui.base.BaseViewModel
 import com.dh.ondot.core.ui.util.ToastManager
 import com.dh.ondot.data.model.TokenModel

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/setting/SettingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/setting/SettingScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.dh.ondot.core.di.openUrl
+import com.dh.ondot.core.platform.openUrl
 import com.dh.ondot.domain.model.enums.OnDotTextStyle
 import com.dh.ondot.presentation.ui.components.OnDotDialog
 import com.dh.ondot.presentation.ui.components.OnDotText

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/setting/term/ServiceTermsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/setting/term/ServiceTermsScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.dh.ondot.core.di.WebView
+import com.dh.ondot.core.platform.WebView
 import com.dh.ondot.domain.model.enums.OnDotTextStyle
 import com.dh.ondot.domain.model.enums.TopBarType
 import com.dh.ondot.getPlatform

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/splash/SplashViewModel.kt
@@ -8,7 +8,7 @@ import com.dh.ondot.core.ui.util.ToastManager
 import com.dh.ondot.data.model.TokenModel
 import com.dh.ondot.domain.model.enums.ToastType
 import com.dh.ondot.domain.repository.AuthRepository
-import com.dh.ondot.network.TokenProvider
+import com.dh.ondot.core.network.TokenProvider
 import com.dh.ondot.presentation.ui.theme.ERROR_LOGIN
 import kotlinx.coroutines.launch
 

--- a/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/ui/theme/String.kt
+++ b/composeApp/src/commonMain/kotlin/com/dh/ondot/presentation/ui/theme/String.kt
@@ -3,6 +3,7 @@ package com.dh.ondot.presentation.ui.theme
 // Platform
 const val ANDROID = "Android"
 const val IOS = "IOS"
+const val DATABASE_NAME = "ondot.db"
 
 // 단어
 const val WORD_NEXT = "다음"

--- a/composeApp/src/commonMain/sqldelight/com/dh/ondot/data/local/db/ScheduleEntity.sq
+++ b/composeApp/src/commonMain/sqldelight/com/dh/ondot/data/local/db/ScheduleEntity.sq
@@ -1,0 +1,42 @@
+import com.dh.ondot.domain.model.response.AlarmDetail;
+import kotlin.Boolean;
+import kotlin.Int;
+import kotlin.collections.List;
+
+CREATE TABLE schedule_entity (
+  scheduleId        INTEGER NOT NULL PRIMARY KEY,
+  startLongitude    REAL    NOT NULL,
+  startLatitude     REAL    NOT NULL,
+  endLongitude      REAL    NOT NULL,
+  endLatitude       REAL    NOT NULL,
+  scheduleTitle     TEXT    NOT NULL,
+  isRepeat          INTEGER AS Boolean NOT NULL,
+  repeatDays        TEXT    AS List<Int> NOT NULL,
+  appointmentAt     TEXT    NOT NULL,
+  preparationAlarm  TEXT AS AlarmDetail NOT NULL,
+  departureAlarm    TEXT AS AlarmDetail NOT NULL,
+  hasActiveAlarm    INTEGER AS Boolean NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_schedule_appointmentAt ON schedule_entity(appointmentAt);
+CREATE INDEX IF NOT EXISTS idx_schedule_hasActive ON schedule_entity(hasActiveAlarm);
+
+-- 기본 쿼리들
+getAll:
+SELECT * FROM schedule_entity ORDER BY appointmentAt ASC;
+
+getById:
+SELECT * FROM schedule_entity WHERE scheduleId = ?;
+
+upsert:
+INSERT OR REPLACE INTO schedule_entity(
+  scheduleId, startLongitude, startLatitude, endLongitude, endLatitude,
+  scheduleTitle, isRepeat, repeatDays, appointmentAt,
+  preparationAlarm, departureAlarm, hasActiveAlarm
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+deleteById:
+DELETE FROM schedule_entity WHERE scheduleId = ?;
+
+clear:
+DELETE FROM schedule_entity;

--- a/composeApp/src/iosMain/kotlin/com/dh/ondot/core/di/PlatformDependencies.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/dh/ondot/core/di/PlatformDependencies.ios.kt
@@ -15,7 +15,7 @@ import com.dh.ondot.domain.service.AlarmScheduler
 import com.dh.ondot.domain.service.AlarmStorage
 import com.dh.ondot.domain.service.MapProviderStorage
 import com.dh.ondot.domain.service.SoundPlayer
-import com.dh.ondot.network.TokenProvider
+import com.dh.ondot.core.network.TokenProvider
 import platform.Foundation.NSBundle
 import platform.Foundation.NSMutableURLRequest
 import platform.Foundation.NSThread

--- a/composeApp/src/iosMain/kotlin/com/dh/ondot/core/network/TokenProvider.kt
+++ b/composeApp/src/iosMain/kotlin/com/dh/ondot/core/network/TokenProvider.kt
@@ -1,4 +1,4 @@
-package com.dh.ondot.network
+package com.dh.ondot.core.network
 
 import com.dh.ondot.data.model.TokenModel
 import platform.Foundation.NSUserDefaults

--- a/composeApp/src/iosMain/kotlin/com/dh/ondot/core/platform/AppleSignIn.kt
+++ b/composeApp/src/iosMain/kotlin/com/dh/ondot/core/platform/AppleSignIn.kt
@@ -1,4 +1,4 @@
-package com.dh.ondot.core.di
+package com.dh.ondot.core.platform
 
 import kotlinx.cinterop.BetaInteropApi
 import platform.AuthenticationServices.ASAuthorization

--- a/composeApp/src/iosMain/kotlin/com/dh/ondot/core/platform/DriverFactory.kt
+++ b/composeApp/src/iosMain/kotlin/com/dh/ondot/core/platform/DriverFactory.kt
@@ -1,0 +1,9 @@
+package com.dh.ondot.core.platform
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import com.dh.ondot.data.local.db.OndotDatabase
+
+actual class DriverFactory {
+    actual fun createDriver(dbName: String): SqlDriver = NativeSqliteDriver(OndotDatabase.Schema, dbName)
+}

--- a/composeApp/src/iosMain/kotlin/com/dh/ondot/core/platform/KakaoSignIn.kt
+++ b/composeApp/src/iosMain/kotlin/com/dh/ondot/core/platform/KakaoSignIn.kt
@@ -1,4 +1,4 @@
-package com.dh.ondot.core.di
+package com.dh.ondot.core.platform
 
 import com.dh.ondot.kakaologin.KakaoLoginHelper
 import kotlinx.cinterop.ExperimentalForeignApi

--- a/composeApp/src/iosMain/kotlin/com/dh/ondot/core/platform/PlatformDependencies.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/dh/ondot/core/platform/PlatformDependencies.ios.kt
@@ -5,17 +5,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.UIKitView
+import com.dh.ondot.core.network.TokenProvider
 import com.dh.ondot.core.util.IosAlarmScheduler
 import com.dh.ondot.core.util.IosAlarmStorage
 import com.dh.ondot.core.util.IosMapProviderStorage
 import com.dh.ondot.core.util.IosSoundPlayer
 import com.dh.ondot.core.util.toUtf8
+import com.dh.ondot.data.local.db.DatabaseFactory
+import com.dh.ondot.data.local.db.OndotDatabase
 import com.dh.ondot.domain.model.enums.MapProvider
 import com.dh.ondot.domain.service.AlarmScheduler
 import com.dh.ondot.domain.service.AlarmStorage
 import com.dh.ondot.domain.service.MapProviderStorage
 import com.dh.ondot.domain.service.SoundPlayer
-import com.dh.ondot.core.network.TokenProvider
 import platform.Foundation.NSBundle
 import platform.Foundation.NSMutableURLRequest
 import platform.Foundation.NSThread
@@ -32,6 +34,10 @@ actual fun provideSoundPlayer(): SoundPlayer = IosSoundPlayer()
 actual fun provideAlarmStorage(): AlarmStorage = IosAlarmStorage()
 
 actual fun provideAlarmScheduler(): AlarmScheduler = IosAlarmScheduler()
+
+actual fun provideDatabase(): OndotDatabase {
+    return DatabaseFactory(DriverFactory()).create()
+}
 
 private fun ensureMain(block: () -> Unit) {
     if (NSThread.isMainThread) block() else dispatch_async(dispatch_get_main_queue()) { block() }

--- a/composeApp/src/iosMain/kotlin/com/dh/ondot/core/platform/PlatformDependencies.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/dh/ondot/core/platform/PlatformDependencies.ios.kt
@@ -1,4 +1,4 @@
-package com.dh.ondot.core.di
+package com.dh.ondot.core.platform
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,6 +73,9 @@ kakao-login = "2.19.0"
 # kotlinx-io
 kotlinx-io = "0.3.0"
 
+# SQLdelight
+sqldelight = "2.1.0"
+
 [plugins]
 androidApplication      = { id = "com.android.application",          version.ref = "agp" }
 androidLibrary          = { id = "com.android.library",              version.ref = "agp" }
@@ -82,6 +85,7 @@ composeMultiplatform    = { id = "org.jetbrains.compose",            version.ref
 composeCompiler         = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 composeHotReload        = { id = "org.jetbrains.compose.hot-reload", version.ref = "composeHotReload"}
 serialization           = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+sqldelight              = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 
 [libraries]
 # Android Gradle Plugin
@@ -176,3 +180,12 @@ kakao-login                    = { module = "com.kakao.sdk:v2-user", version.ref
 # kotlinx-io
 kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
 kotlinx-io-bytestring = { module = "org.jetbrains.kotlinx:kotlinx-io-bytestring", version.ref = "kotlinx-io" }
+
+# Coroutine Extensions
+coroutines-extensions = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
+
+# AndroidDriver
+android-driver                         = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
+
+# NativeDriver
+native-driver                          = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Android / Kotlin 플랫폼
-agp = "8.6.1"
+agp = "8.12.2"
 android-compileSdk = "36"
 android-minSdk = "26"
 android-targetSdk = "36"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 # Android / Kotlin 플랫폼
 agp = "8.6.1"
-android-compileSdk = "35"
+android-compileSdk = "36"
 android-minSdk = "26"
-android-targetSdk = "35"
+android-targetSdk = "36"
 android-application = "8.4.2"
 
 kotlin = "2.1.21"
@@ -76,6 +76,9 @@ kotlinx-io = "0.3.0"
 # SQLdelight
 sqldelight = "2.1.0"
 
+# BuildKonfig
+buildkonfig = "0.17.1"
+
 [plugins]
 androidApplication      = { id = "com.android.application",          version.ref = "agp" }
 androidLibrary          = { id = "com.android.library",              version.ref = "agp" }
@@ -86,6 +89,7 @@ composeCompiler         = { id = "org.jetbrains.kotlin.plugin.compose", version.
 composeHotReload        = { id = "org.jetbrains.compose.hot-reload", version.ref = "composeHotReload"}
 serialization           = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 sqldelight              = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
+buildKonfig             = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig" }
 
 [libraries]
 # Android Gradle Plugin

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## 이슈 번호
- close #67 

## 작업내용
### commonMain
- [x] sqldelight 플러그인 설정
- [x] Schedule.sq 스키마 파일 정의
- [x] ScheduleRepositryImpl 로직 수정

### androidMain
- [x] 앱 초기화 로직에서 데이터베이스 인스턴스 제공

### iosMain
- [x] 데이터베이스 인스턴스 제공


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 로컬 데이터베이스 도입으로 일정 데이터가 앱에 저장되어 더 빠르게 로드되며, 오프라인에서도 일정 상세 조회가 가능합니다.
  - 빌드별 서버 주소 설정을 지원해 환경 전환이 유연해졌습니다.

- 개선
  - 네트워크 요청에 자동 재시도 로직을 적용해 통신 안정성을 높였습니다.

- 리팩터
  - 플랫폼/코어 패키지 구조를 정리하여 코드 가독성과 유지보수성을 향상했습니다. 기능 변화는 없습니다.

- 작업
  - Android targetSdk를 36으로 업데이트했습니다.
  - 빌드 플러그인 및 멀티플랫폼 의존성을 추가해 프로젝트 빌드 안정성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->