### PR TITLE
Fix: 일정 생성 오류 수정 

### DIFF
--- a/feature/general/src/commonMain/kotlin/com/ondot/general/GeneralScheduleViewModel.kt
+++ b/feature/general/src/commonMain/kotlin/com/ondot/general/GeneralScheduleViewModel.kt
@@ -119,7 +119,7 @@ class GeneralScheduleViewModel(
     /**--------------------------------------------RepeatSettingSection-----------------------------------------------*/
 
     fun onClickSwitch(newValue: Boolean) {
-        updateState(uiState.value.copy(isRepeat = newValue))
+        updateState(uiState.value.copy(isRepeat = newValue, selectedDate = null))
 
         logGA("repeat_toggle", "enabled" to newValue)
 


### PR DESCRIPTION
## 이슈 번호
- close #112 
## 작업내용

* 반복 일정 토글이 활성화될 때 selectedDate를 null로 초기화는 로직을 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 반복 일정 설정을 토글할 때 이전에 선택했던 날짜가 자동으로 초기화되도록 개선되었습니다. 이를 통해 반복 설정 변경 시 날짜 데이터가 올바르게 관리됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->